### PR TITLE
feat: optional store fields and cash ticket paid mapping to main

### DIFF
--- a/app/Events/CreditCreated.php
+++ b/app/Events/CreditCreated.php
@@ -35,6 +35,7 @@ class CreditCreated
                 'invoice_number' => $this->credit->invoice->invoice_number ?? '',
                 'store_name' => $this->credit->store->name ?? '',
                 'created_at' => now()->format('Y-m-d H:i:s'),
+                'store_currency' => $this->credit->store->store_currency ?? 'C$',
             ]
         ];
     }

--- a/app/Events/InvoiceCreated.php
+++ b/app/Events/InvoiceCreated.php
@@ -39,6 +39,7 @@ class InvoiceCreated
                 'total_items' => $this->invoice->total,
                 'discount' => $this->invoice->discount,
                 'tax' => $this->invoice->tax,
+                'store_currency' => $this->invoice->store->store_currency ?? 'C$',
             ]
         ];
     }

--- a/app/Notifications/DynamicSystemNotification.php
+++ b/app/Notifications/DynamicSystemNotification.php
@@ -102,7 +102,14 @@ class DynamicSystemNotification extends Notification implements ShouldQueue
                     'bacs' => 'Transferencia',
                 ];
 
+                $currency = $this->data['store_currency'] ?? '';
+
                 foreach ($this->data as $key => $val) {
+                    // Evitar pintar la variable de moneda como un elemento de lista independiente
+                    if ($key === 'store_currency') {
+                        continue;
+                    }
+
                     $label = $translations[$key] ?? ucwords(str_replace('_', ' ', $key));
                     
                     // Traducir valores específicos si son de tipo string
@@ -110,9 +117,10 @@ class DynamicSystemNotification extends Notification implements ShouldQueue
                         ? $valueTranslations[strtolower($val)]
                         : $val;
 
-                    // Formatear montos numéricos de dinero
+                    // Formatear montos numéricos de dinero con la moneda de la tienda en lugar del signo $
                     if (in_array($key, ['grand_total', 'total', 'debt', 'tax', 'discount']) && is_numeric($displayVal)) {
-                        $displayVal = '$' . number_format((float)$displayVal, 2);
+                        $formattedNum = number_format((float)$displayVal, 2);
+                        $displayVal = $currency ? $currency . ' ' . $formattedNum : $formattedNum;
                     }
 
                     $body .= '<li><strong>' . e($label) . ':</strong> ' . e((string)$displayVal) . '</li>';
@@ -126,6 +134,12 @@ class DynamicSystemNotification extends Notification implements ShouldQueue
             // Reemplazar las variables dinámicas {variable}
             foreach ($this->data as $key => $val) {
                 $placeholder = '{' . $key . '}';
+                // Si la variable a reemplazar es un monto de dinero, formatearla adecuadamente
+                if (in_array($key, ['grand_total', 'total', 'debt', 'tax', 'discount']) && is_numeric($val)) {
+                    $currency = $this->data['store_currency'] ?? '';
+                    $formattedNum = number_format((float)$val, 2);
+                    $val = $currency ? $currency . ' ' . $formattedNum : $formattedNum;
+                }
                 $subject = str_replace($placeholder, (string)$val, $subject);
                 $body = str_replace($placeholder, (string)$val, $body);
             }

--- a/app/Notifications/DynamicSystemNotification.php
+++ b/app/Notifications/DynamicSystemNotification.php
@@ -146,9 +146,14 @@ class DynamicSystemNotification extends Notification implements ShouldQueue
         }
 
         // Obtener el destinatario
-        $recipientEmail = $notifiable->routeNotificationFor('mail', $this);
-        if (!$recipientEmail && is_string($notifiable)) {
+        $recipientEmail = null;
+        if (is_string($notifiable)) {
             $recipientEmail = $notifiable;
+        } elseif (method_exists($notifiable, 'routeNotificationFor')) {
+            $recipientEmail = $notifiable->routeNotificationFor('mail', $this);
+        }
+        if (!$recipientEmail) {
+            $recipientEmail = $notifiable->email ?? null;
         }
 
         // Retornar la estructura Mailable dinámica


### PR DESCRIPTION
Makes description, address, phone, email optional on backend store validation, extracts paid_in_nio/paid_in_usd directly on invoice creation, and formats email notification currencies dynamically using the store currency prefix without hardcoded symbols.