### PR TITLE
fix: deadlock 1205 en registro de organización + licencia trial de 14 días

### DIFF
--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -20,6 +20,9 @@ use App\Models\Role;
 
 class OrganizationController extends Controller
 {
+    // Días de licencia de prueba otorgados al registrar una organización.
+    private const TRIAL_DAYS = 14;
+
     public function index()
     {
         return response(['message' => 'Not Found'], Response::HTTP_NOT_FOUND);
@@ -27,98 +30,138 @@ class OrganizationController extends Controller
 
     public function store(StoreOrganizationRequest $request)
     {
+        // Guard rápido (la verificación autoritativa se repite dentro de la
+        // transacción, con el row del user bloqueado).
         if ($request->user()->organization()->exists()) {
             return response(['message' => 'User already has an organization'], Response::HTTP_CONFLICT);
         }
 
         $this->validateUniqueFields($request);
 
-        DB::connection('central')->beginTransaction();
-        
+        $owner_id = $request->user()->id;
+        $request->merge(['owner_id' => $owner_id]);
+
+        // Subir el logo ANTES de la transacción: dentro solo operaciones de BD.
+        $logoPath = null;
+        if ($request->hasFile('logo')) {
+            $logoPath = $request->file('logo')->store('organizationLogo', 'public');
+        }
+
         try {
-            $owner_id = $request->user()->id;
-            $request->merge(['owner_id' => $owner_id]);
+            // TODO el flujo debe correr por UNA sola conexión ('central', donde
+            // viven User/Organization/Role/Permission). Mezclar conexiones contra
+            // el mismo esquema produce un auto-deadlock: el INSERT de sellers en
+            // una conexión deja bloqueada la fila, y el chequeo de FK
+            // (users.seller_id -> sellers.id) desde la otra conexión del MISMO
+            // request espera ese lock hasta el timeout 1205. Por eso el seller
+            // se crea con Seller::on('central') (mismo esquema físico).
+            $result = DB::connection('central')->transaction(function () use ($request, $owner_id, $logoPath) {
+                // Serializar por usuario: requests concurrentes del mismo user
+                // esperan este lock en vez de chocar en el índice único de
+                // sellers.code (otra causa del lock wait timeout 1205).
+                $user = User::whereKey($owner_id)->lockForUpdate()->first();
 
-            // 1. Crear la organización
-            $organization = Organization::create($request->all());
+                if (!$user instanceof User) {
+                    throw new \Exception('User not found or not authenticated');
+                }
 
-            if ($request->hasFile('logo')) {
-                $organization->logo = $request->file('logo')->store('organizationLogo', 'public');
-                $organization->save();
+                // Re-chequeo dentro de la transacción: un request concurrente
+                // pudo haber creado la organización mientras esperábamos el lock.
+                if ($user->organization()->exists()) {
+                    return ['conflict' => true];
+                }
+
+                // 1. Crear la organización
+                $organization = Organization::create($request->all());
+
+                if ($logoPath) {
+                    $organization->logo = $logoPath;
+                    $organization->save();
+                }
+
+                // 1b. Otorgar licencia de prueba (las licencias se manejan por días)
+                $trialExpiresAt = now()->addDays(self::TRIAL_DAYS);
+                $organization->licenses()->create([
+                    'type' => 'add',
+                    'days' => self::TRIAL_DAYS,
+                    'previous_expires_at' => null,
+                    'new_expires_at' => $trialExpiresAt,
+                ]);
+                $organization->update(['license_expires_at' => $trialExpiresAt]);
+
+                // 2. Asociar todos los módulos activos del sistema a esta nueva organización
+                $modules = Module::where('status', 'active')->get();
+                if ($modules->isEmpty()) {
+                    throw new \Exception('No active modules found in system database. Please run seeders first.');
+                }
+                foreach ($modules as $mod) {
+                    $organization->modules()->syncWithoutDetaching([$mod->id => ['status' => 'active']]);
+                }
+
+                // 3. Crear el rol 'Owner' (acceso total) para esta organización
+                $allPermissions = Permission::all();
+                if ($allPermissions->isEmpty()) {
+                    throw new \Exception('No permissions found in system database. Please run seeders first.');
+                }
+                $ownerRole = Role::firstOrCreate(
+                    ['name' => 'Owner', 'organization_id' => $organization->id],
+                    ['guard_name' => 'web']
+                );
+                $ownerRole->syncPermissions($allPermissions);
+
+                // 4. Definir y crear los roles 'Manager' y 'Seller' con sus respectivos permisos
+                $sellerPermissions = [
+                    'invoice.index', 'invoice.show', 'invoice.store',
+                    'client.index', 'client.show', 'client.store', 'client.update',
+                    'product.index', 'product.show',
+                    'inventory.index', 'inventory.show',
+                    'credit.index', 'credit.show', 'credit.payment',
+                    'seller.index', 'seller.show',
+                ];
+                $managerPermissions = array_merge($sellerPermissions, [
+                    'product.store', 'product.update',
+                    'inventory.store', 'inventory.update',
+                    'supplier.index', 'supplier.show', 'supplier.store', 'supplier.update',
+                    'purchase.index', 'purchase.show', 'purchase.store',
+                    'report.index', 'report.store', 'report.download',
+                ]);
+
+                $managerRole = Role::firstOrCreate(
+                    ['name' => 'Manager', 'organization_id' => $organization->id],
+                    ['guard_name' => 'web']
+                );
+                $managerRole->syncPermissions($managerPermissions);
+
+                $sellerRole = Role::firstOrCreate(
+                    ['name' => 'Seller', 'organization_id' => $organization->id],
+                    ['guard_name' => 'web']
+                );
+                $sellerRole->syncPermissions($sellerPermissions);
+
+                // 5. Asignar el rol de Owner y vincular la organización al usuario creador
+                $user->update([
+                    'organization_id' => $organization->id,
+                    'role_id'         => $ownerRole->uuid,
+                ]);
+                $user->assignRole($ownerRole);
+
+                // 6. Crear el perfil de Vendedor (Seller) para el propietario
+                $seller = $this->createOwnerSeller($user, $organization);
+                $user->update(['seller_id' => $seller->id]);
+
+                return ['organization' => $organization];
+            });
+
+            if (isset($result['conflict'])) {
+                return response(['message' => 'User already has an organization'], Response::HTTP_CONFLICT);
             }
 
-            $user = Auth::user();
-            
-            if (!$user instanceof User) {
-                throw new \Exception('User not found or not authenticated');
-            }
-
-            // 2. Asociar todos los módulos activos del sistema a esta nueva organización
-            $modules = Module::where('status', 'active')->get();
-            if ($modules->isEmpty()) {
-                throw new \Exception('No active modules found in system database. Please run seeders first.');
-            }
-            foreach ($modules as $mod) {
-                $organization->modules()->syncWithoutDetaching([$mod->id => ['status' => 'active']]);
-            }
-
-            // 3. Crear el rol 'Owner' (acceso total) para esta organización
-            $allPermissions = Permission::all();
-            if ($allPermissions->isEmpty()) {
-                throw new \Exception('No permissions found in system database. Please run seeders first.');
-            }
-            $ownerRole = Role::firstOrCreate(
-                ['name' => 'Owner', 'organization_id' => $organization->id],
-                ['guard_name' => 'web']
-            );
-            $ownerRole->syncPermissions($allPermissions);
-
-            // 4. Definir y crear los roles 'Manager' y 'Seller' con sus respectivos permisos
-            $sellerPermissions = [
-                'invoice.index', 'invoice.show', 'invoice.store',
-                'client.index', 'client.show', 'client.store', 'client.update',
-                'product.index', 'product.show',
-                'inventory.index', 'inventory.show',
-                'credit.index', 'credit.show', 'credit.payment',
-                'seller.index', 'seller.show',
-            ];
-            $managerPermissions = array_merge($sellerPermissions, [
-                'product.store', 'product.update',
-                'inventory.store', 'inventory.update',
-                'supplier.index', 'supplier.show', 'supplier.store', 'supplier.update',
-                'purchase.index', 'purchase.show', 'purchase.store',
-                'report.index', 'report.store', 'report.download',
-            ]);
-
-            $managerRole = Role::firstOrCreate(
-                ['name' => 'Manager', 'organization_id' => $organization->id],
-                ['guard_name' => 'web']
-            );
-            $managerRole->syncPermissions($managerPermissions);
-
-            $sellerRole = Role::firstOrCreate(
-                ['name' => 'Seller', 'organization_id' => $organization->id],
-                ['guard_name' => 'web']
-            );
-            $sellerRole->syncPermissions($sellerPermissions);
-
-            // 5. Asignar el rol de Owner y vincular la organización al usuario creador
-            $user->update([
-                'organization_id' => $organization->id,
-                'role_id'         => $ownerRole->uuid,
-            ]);
-            $user->assignRole($ownerRole);
-
-            // 6. Crear el perfil de Vendedor (Seller) para el propietario
-            $seller = $this->createOwnerSeller($user, $organization);
-            $user->update(['seller_id' => $seller->id]);
-
-            DB::connection('central')->commit();
-
-            return response(new OrganizationResource($organization), Response::HTTP_CREATED);
-            
+            return response(new OrganizationResource($result['organization']), Response::HTTP_CREATED);
         } catch (\Exception $e) {
-            DB::connection('central')->rollBack();
+            // DB::transaction ya hizo rollback; limpiar el logo subido a disco.
+            if ($logoPath) {
+                \Illuminate\Support\Facades\Storage::disk('public')->delete($logoPath);
+            }
             return response(['message' => 'Error creating organization: ' . $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
@@ -217,13 +260,22 @@ class OrganizationController extends Controller
 
     private function createOwnerSeller(User $user, Organization $organization)
     {
-        return Seller::create([
-            'organization_id' => $organization->id,
-            'name'            => $user->name,
-            'code'            => 'OWNER-' . strtoupper(substr($user->id, 0, 6)), 
-            'status'          => 'active',
-            'is_owner'        => true,
-            'pin_hash'        => Hash::make('1234'), 
-        ]);
+        // Idempotente: un reintento del registro no debe chocar con el índice
+        // único de `code` si el seller del owner ya quedó creado.
+        // Va por la conexión 'central' (mismo esquema físico que la default)
+        // para que participe de la transacción de store() y las FKs
+        // (sellers.organization_id, users.seller_id) no crucen conexiones.
+        return Seller::on('central')->firstOrCreate(
+            [
+                'organization_id' => $organization->id,
+                'is_owner'        => true,
+            ],
+            [
+                'name'     => $user->name,
+                'code'     => 'OWNER-' . strtoupper(substr($user->id, 0, 6)),
+                'status'   => 'active',
+                'pin_hash' => Hash::make('1234'),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Problema

`POST /api/v1/organizations` tardaba ~50s y fallaba con `SQLSTATE[HY000] 1205 Lock wait timeout` al insertar el seller del owner, dejando organizaciones huérfanas (ej. "La tuani").

## Causa raíz

Las conexiones `central` y `mysql` apuntan al mismo esquema físico. La transacción abierta en `central` dejaba la organización sin commitear, y el `INSERT` de `sellers` (conexión `mysql`) quedaba esperando el lock del chequeo de FK (`sellers.organization_id → organizations.id`) de su **propio request** → auto-deadlock hasta el timeout. Capturado en vivo con `performance_schema.data_locks`.

## Fix

- Transacción única en `central`; el seller se crea con `Seller::on('central')` para que participe de la misma transacción (el rollback ahora deshace todo — no más huérfanos).
- `lockForUpdate()` sobre el user + re-chequeo de `organization()->exists()` dentro de la transacción: requests concurrentes reciben 409 en vez de duplicar o bloquearse.
- Seller del owner idempotente (`firstOrCreate` por `organization_id` + `is_owner`).
- Subida de logo fuera de la transacción (solo BD adentro), con limpieza del archivo si falla.
- **Trial de 14 días** al registrar: registro en `organization_licenses` (`type=add, days=14`) + `license_expires_at`. Cierra el hueco donde toda org nueva quedaba bloqueada con `402 LICENSE_EXPIRED`.

## Verificación (local)

- Registro: de 502 en 32s → **201 en 0.6s**, con seller, roles, módulos y licencia consistentes.
- 3 requests concurrentes idénticos → un 201 y dos 409 en <0.7s, sin 1205.
- Request post-registro → 200 (antes 402 por falta de licencia).

## Post-deploy

- Matar transacciones colgadas (`information_schema.innodb_trx` → `KILL`).
- Limpiar la org huérfana `a0ecbfbd-7007-4414-aa13-891238967166` y desvincular su user (SQL en el hilo de trabajo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)