### PR TITLE
feat: sincronización idempotente de ventas offline del POS

### DIFF
--- a/app/Http/Controllers/Api/V1/InvoiceController.php
+++ b/app/Http/Controllers/Api/V1/InvoiceController.php
@@ -139,6 +139,19 @@ class InvoiceController extends Controller
     {
         $this->authorize('create', Invoice::class);
 
+        // Idempotencia para sincronización offline: si la factura ya fue creada
+        // con esta referencia, devolver la existente en lugar de duplicarla.
+        if ($request->filled('offline_reference')) {
+            $existing = Invoice::where('offline_reference', $request->offline_reference)
+                ->where('organization_id', Auth::user()->organization_id)
+                ->first();
+
+            if ($existing) {
+                $existing->load('client');
+                return new InvoiceResource($existing);
+            }
+        }
+
         $lockKey = 'create_invoice_' . Auth::id() . '_' . md5(json_encode($request->all()));
         $lock = Cache::lock($lockKey, 5); // Bloqueo de 5 segundos para evitar doble envío
 
@@ -169,6 +182,25 @@ class InvoiceController extends Controller
         } catch (\Throwable $e) {
             DB::rollBack();
             $lock->release();
+
+            // Carrera residual de idempotencia: otro proceso insertó la misma
+            // offline_reference entre el check inicial y el create. Tras el
+            // rollback (fuera de la transacción) la fila commiteada ya es visible.
+            if (
+                $e instanceof \Illuminate\Database\QueryException &&
+                $e->getCode() === '23000' &&
+                $request->filled('offline_reference')
+            ) {
+                $existing = Invoice::where('offline_reference', $request->offline_reference)
+                    ->where('organization_id', Auth::user()->organization_id)
+                    ->first();
+
+                if ($existing) {
+                    $existing->load('client');
+                    return new InvoiceResource($existing);
+                }
+            }
+
             report($e);
             return response()->json(['message' => 'Error al procesar la factura.', 'error' => $e->getMessage()], 500);
         }
@@ -388,6 +420,17 @@ class InvoiceController extends Controller
         $invoiceData['user_id'] = $userID;
         $invoiceData['organization_id'] = $orgId;
         $invoiceData['cash_session_id'] = $isProforma ? null : $request->cash_session_id;
+
+        // Metadatos de venta offline (sincronización desde el POS sin conexión)
+        $isOffline = filter_var($request->is_offline, FILTER_VALIDATE_BOOLEAN);
+        $invoiceData['offline_reference'] = $request->offline_reference;
+        $invoiceData['is_offline'] = $isOffline;
+        $invoiceData['offline_number'] = $request->offline_number;
+
+        if ($isOffline && $request->offline_number) {
+            $offlineTag = "[OFFLINE {$request->offline_number}]";
+            $invoiceData['invoice_note'] = trim($offlineTag . ' ' . ($invoiceData['invoice_note'] ?? ''));
+        }
 
         // Extraer y mapear valores de pago en efectivo directamente a las columnas del modelo
         $paidInNio = 0.0;

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -37,6 +37,9 @@ class StoreInvoiceRequest extends FormRequest
             'products' => 'required',
             'source' => 'nullable|string|in:POS,ADMIN,MOBILE_APP,ECOMMERCE',
             'seller_id' => 'nullable|string|exists:sellers,id',
+            'offline_reference' => 'nullable|uuid',
+            'is_offline' => 'nullable|boolean',
+            'offline_number' => 'nullable|string|max:30',
         ];
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -37,6 +37,9 @@ class Invoice extends Model
         'payment_metadata',
         'cash_session_id',
         'source',
+        'offline_reference',
+        'is_offline',
+        'offline_number',
     ];
 
     protected $casts = [

--- a/database/migrations/2026_07_17_120000_add_offline_fields_to_invoices_table.php
+++ b/database/migrations/2026_07_17_120000_add_offline_fields_to_invoices_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->uuid('offline_reference')->nullable()->unique()->after('source');
+            $table->boolean('is_offline')->default(false)->after('offline_reference');
+            $table->string('offline_number', 30)->nullable()->after('is_offline');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropUnique(['offline_reference']);
+            $table->dropColumn(['offline_reference', 'is_offline', 'offline_number']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,6 +46,11 @@ Route::prefix('v1')->group(function () {
         }
     );
 
+    // Ping liviano sin auth para detección de conectividad del POS offline
+    Route::get('/ping', function () {
+        return response()->json(['ok' => true, 'ts' => now()->timestamp]);
+    });
+
     Route::post('/login', [LoginController::class, 'login']);
     Route::post('/register', [LoginController::class, 'registerOwner']);
     Route::post('/forgot-password', [PasswordResetController::class, 'forgotPassword']);


### PR DESCRIPTION
## Contexto

Parte backend del **Modo Offline** de DipleBill Seller (PR complementario en `DipleBill-seller`): el POS encola ventas en IndexedDB durante caídas de internet y las sincroniza al reconectar.

## Cambios

- **Migración** en `invoices`: `offline_reference` (uuid, unique), `is_offline`, `offline_number` (correlativo temporal `OFF-YYMMDD-####` impreso en el ticket físico).
- **Idempotencia en `POST /v1/invoices`**: si la `offline_reference` ya existe para la organización, se devuelve la factura existente (200) en vez de duplicarla. Cubre también la carrera residual: dedupe tras rollback ante `QueryException` 23000 (fuera de la transacción, para que la fila commiteada por el otro proceso sea visible).
- El correlativo oficial lo sigue asignando el servidor al sincronizar; las facturas offline conservan su `invoice_date` real, su `cash_session_id` original y la nota `[OFFLINE OFF-...]`.
- **`GET /v1/ping`** sin autenticación, para que el POS confirme conectividad real (redes zombie / portales cautivos).

## Verificación

- `php artisan migrate` OK en local.
- `/v1/ping` responde sin auth; `/v1/invoices` sigue protegido.
- El flujo E2E completo se prueba junto con el PR del frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)