### PR TITLE
hotfix: install mysql client so production backups work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM php:8.2-fpm
 
 # Instalar dependencias del sistema y extensiones de PHP requeridas por Laravel
+# default-mysql-client provee mysqldump, requerido por spatie/laravel-backup.
 RUN apt-get update && apt-get install -y \
     git \
     curl \
@@ -11,7 +12,8 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     nginx \
-    supervisor
+    supervisor \
+    default-mysql-client
 
 # Limpiar cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problema
Los backups en producción fallaban con:
```
sh: 1: mysqldump: Permission denied
Exitcode 127: Command not found
```

## Causa
El `Dockerfile` (imagen `php:8.2-fpm`) instala PHP y sus extensiones, pero nunca instala un cliente de MySQL. `mysqldump` no existe dentro del contenedor, por lo que `spatie/laravel-backup` no puede volcar la base de datos.

## Fix
Agrega `default-mysql-client` (paquete Debian) a la instalación de dependencias del sistema en el `Dockerfile`.

## Después de mergear
Este cambio requiere **reconstruir la imagen Docker** — no toma efecto solo con el merge. En Coolify: ir al servicio **Backend** → Redeploy (forzando rebuild desde el Dockerfile actualizado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
