### PR TITLE
Launch hardening: infra Docker, facturas de suscripción, correos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,20 +55,27 @@ MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Bucket para respaldos off-site (S3 / Backblaze B2 / DigitalOcean Spaces).
+# Para B2/Spaces define además AWS_ENDPOINT y AWS_USE_PATH_STYLE_ENDPOINT=true.
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
+AWS_ENDPOINT=
+AWS_URL=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
-# Respaldos de base de datos (spatie/laravel-backup)
-# En producción usar BACKUP_DISK=s3 (con las credenciales AWS de arriba, o un
-# bucket de Backblaze B2 / DigitalOcean Spaces vía el driver s3) para que los
-# respaldos salgan del servidor. Requiere el cron del scheduler activo:
-#   * * * * * cd /ruta/al/proyecto && php artisan schedule:run >> /dev/null 2>&1
+# Respaldos de base de datos (spatie/laravel-backup).
+# PRODUCCIÓN: usar BACKUP_DISK=s3 con un bucket real para que los respaldos NO
+# vivan dentro del contenedor (un redeploy borraría el disco 'local'). El
+# scheduler ya corre dentro del contenedor (supervisord → schedule:work).
 BACKUP_DISK=local
 BACKUP_ARCHIVE_NAME=DipleBill
 BACKUP_NOTIFICATION_EMAIL=soporte@diplebill.com
+
+# Telescope: SOLO desarrollo. En producción la imagen se construye con
+# 'composer install --no-dev' (no lo instala) y esta bandera queda en false.
+TELESCOPE_ENABLED=false
 
 VITE_APP_NAME="${APP_NAME}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Instalar extensiones de PHP
 RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
 
+# Límites de subida (comprobantes/capturas). Sobrescribe los defaults de PHP.
+COPY ./docker/php/uploads.ini /usr/local/etc/php/conf.d/zz-uploads.ini
+
 # Obtener Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
@@ -30,19 +33,24 @@ WORKDIR /var/www
 # Copiar archivos del proyecto
 COPY . /var/www
 
-# Instalar dependencias de composer (optimizadas para prod)
-RUN composer install --no-interaction --prefer-dist --optimize-autoloader
+# Instalar dependencias de composer SOLO de producción (sin dev: fuera Telescope,
+# Pint, Sail, etc. que no deben correr ni exponerse en producción).
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 
 # Dar permisos a las carpetas de almacenamiento
 RUN chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 
-# Copiar configuración de Nginx (Crearemos este archivo en el Paso 1.1)
+# Copiar configuración de Nginx
 COPY ./docker/nginx/conf.d/app.conf /etc/nginx/conf.d/default.conf
-# Copiar configuración de Supervisor (Crearemos este archivo en el Paso 1.2)
+# Copiar configuración de Supervisor
 COPY ./docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Entrypoint de arranque (storage:link, migraciones, caches) antes de supervisord.
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Exponer el puerto 80
 EXPOSE 80
 
-# Comando de inicio (Inicia Supervisor que gestiona Nginx y PHP)
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+# El entrypoint prepara el estado y luego hace exec de supervisord.
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/app/Console/Commands/NotifyExpiringLicenses.php
+++ b/app/Console/Commands/NotifyExpiringLicenses.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Mail\LicenseExpiringMail;
-use App\Models\GlobalSetting;
 use App\Models\Organization;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
@@ -26,10 +25,8 @@ class NotifyExpiringLicenses extends Command
             ->filter()
             ->all();
 
-        $paymentInfo = [
-            'account' => GlobalSetting::where('key', 'payment_account')->value('value') ?? '',
-            'whatsapp' => GlobalSetting::where('key', 'payment_whatsapp')->value('value') ?? '',
-        ];
+        // Usar el SMTP configurado en el panel (no el MAIL_* del .env).
+        \App\Services\MailConfigurator::applyConfiguration();
 
         $sent = 0;
         $summary = [];
@@ -55,8 +52,7 @@ class NotifyExpiringLicenses extends Command
                 Mail::to($email)->send(new LicenseExpiringMail(
                     name: $org->user?->name ?? $org->name,
                     daysLeft: $days,
-                    expiresAt: $org->license_expires_at->format('d/m/Y'),
-                    paymentInfo: $paymentInfo
+                    expiresAt: $org->license_expires_at->format('d/m/Y')
                 ));
                 $sent++;
             }

--- a/app/Http/Controllers/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Admin/AdminDashboardController.php
@@ -346,15 +346,22 @@ class AdminDashboardController extends Controller
         $googleClientId = GlobalSetting::where('key', 'google_client_id')->value('value') ?? '';
         $googleClientSecret = GlobalSetting::where('key', 'google_client_secret')->value('value') ?? '';
         $googleRedirectUri = GlobalSetting::where('key', 'google_redirect_uri')->value('value') ?? '';
-        $paymentAccount = GlobalSetting::where('key', 'payment_account')->value('value') ?? '';
-        $paymentWhatsapp = GlobalSetting::where('key', 'payment_whatsapp')->value('value') ?? '';
+        // Datos del emisor para las facturas de suscripción.
+        $company = [
+            'company_legal_name' => GlobalSetting::where('key', 'company_legal_name')->value('value') ?? 'DipleBill',
+            'company_ruc'        => GlobalSetting::where('key', 'company_ruc')->value('value') ?? '',
+            'company_address'    => GlobalSetting::where('key', 'company_address')->value('value') ?? '',
+            'company_phone'      => GlobalSetting::where('key', 'company_phone')->value('value') ?? '',
+            'company_email'      => GlobalSetting::where('key', 'company_email')->value('value') ?? '',
+            'company_website'    => GlobalSetting::where('key', 'company_website')->value('value') ?? '',
+        ];
+
         return view('admin.settings.index', compact(
             'supportMessage',
             'googleClientId',
             'googleClientSecret',
             'googleRedirectUri',
-            'paymentAccount',
-            'paymentWhatsapp'
+            'company'
         ));
     }
 
@@ -365,8 +372,12 @@ class AdminDashboardController extends Controller
             'google_client_id' => 'nullable|string',
             'google_client_secret' => 'nullable|string',
             'google_redirect_uri' => 'nullable|string',
-            'payment_account' => 'nullable|string',
-            'payment_whatsapp' => 'nullable|string',
+            'company_legal_name' => 'nullable|string',
+            'company_ruc' => 'nullable|string',
+            'company_address' => 'nullable|string',
+            'company_phone' => 'nullable|string',
+            'company_email' => 'nullable|email',
+            'company_website' => 'nullable|string',
         ]);
 
         $keys = [
@@ -374,8 +385,12 @@ class AdminDashboardController extends Controller
             'google_client_id',
             'google_client_secret',
             'google_redirect_uri',
-            'payment_account',
-            'payment_whatsapp',
+            'company_legal_name',
+            'company_ruc',
+            'company_address',
+            'company_phone',
+            'company_email',
+            'company_website',
         ];
 
         foreach ($keys as $key) {

--- a/app/Http/Controllers/Admin/AdminPaymentController.php
+++ b/app/Http/Controllers/Admin/AdminPaymentController.php
@@ -8,6 +8,7 @@ use App\Models\PaymentProvider;
 use App\Models\PaymentSubmission;
 use App\Models\Plan;
 use App\Services\AdminAudit;
+use App\Services\AdminNotifier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -72,6 +73,17 @@ class AdminPaymentController extends Controller
 
     // ---- Validación de comprobantes ----
 
+    /** Descarga la factura de suscripción emitida para un comprobante aprobado. */
+    public function downloadInvoice($id)
+    {
+        $invoice = \App\Models\SubscriptionInvoice::where('payment_submission_id', $id)->firstOrFail();
+
+        return response(\App\Services\SubscriptionInvoiceService::renderPdf($invoice), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . \App\Services\SubscriptionInvoiceService::filename($invoice) . '"',
+        ]);
+    }
+
     /** Muestra el comprobante subido por el cliente (imagen o PDF). */
     public function viewReceipt($id)
     {
@@ -100,11 +112,16 @@ class AdminPaymentController extends Controller
 
         // Si el comprobante trae un plan, se asigna y se extiende la licencia por
         // su duración. Reutiliza la misma lógica de asignación del panel.
-        if ($submission->plan_id && ($plan = Plan::find($submission->plan_id))) {
+        $plan = $submission->plan_id ? Plan::find($submission->plan_id) : null;
+        $periodStart = null;
+        $periodEnd = null;
+        if ($plan) {
             $baseDate = ($organization->license_expires_at && $organization->license_expires_at->isFuture())
                 ? $organization->license_expires_at
                 : now();
             $newExpiresAt = $baseDate->copy()->addMonths($plan->duration_months);
+            $periodStart = $baseDate;
+            $periodEnd = $newExpiresAt;
 
             $organization->licenses()->create([
                 'type' => 'add',
@@ -127,21 +144,53 @@ class AdminPaymentController extends Controller
             'reviewed_at' => now(),
         ]);
 
+        // Emitir la factura de DipleBill hacia el cliente (PDF descargable). No debe
+        // romper la aprobación si algo falla.
+        $invoice = null;
+        try {
+            $submission->loadMissing('provider');
+            $invoice = \App\Services\SubscriptionInvoiceService::createFromSubmission(
+                $submission,
+                $organization,
+                $plan,
+                $periodStart,
+                $periodEnd,
+                \Illuminate\Support\Facades\Auth::guard('admin')->id()
+            );
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::warning('No se pudo emitir la factura de suscripción: ' . $e->getMessage());
+        }
+
         AdminAudit::log('payment.approve', 'organization', $organization->id,
             "Comprobante aprobado de {$organization->name}" . ($submission->plan_id ? " (plan renovado)" : ''));
 
-        // Notificar al cliente y avisar internamente de la renovación.
+        // Notificar al cliente (con la factura PDF adjunta) y avisar internamente.
         $planName = $submission->plan?->name;
         $expiresLabel = $organization->license_expires_at?->format('d/m/Y');
-        AdminNotifier::notifyClient(
-            $organization->user?->email ?? $organization->email,
-            '✅ Tu renovación fue aprobada — DipleBill',
-            '<h2>¡Renovación confirmada!</h2>'
-                . '<p>Validamos tu comprobante y tu licencia quedó activa.</p>'
-                . ($planName ? '<p><strong>Plan:</strong> ' . e($planName) . '</p>' : '')
-                . ($expiresLabel ? '<p><strong>Válida hasta:</strong> ' . e($expiresLabel) . '</p>' : '')
-                . '<p>¡Gracias por seguir con nosotros!</p>'
-        );
+        $clientEmail = $organization->user?->email ?? $organization->email;
+        $bodyHtml = '<h2>¡Renovación confirmada!</h2>'
+            . '<p>Validamos tu comprobante y tu licencia quedó activa.</p>'
+            . ($planName ? '<p><strong>Plan:</strong> ' . e($planName) . '</p>' : '')
+            . ($expiresLabel ? '<p><strong>Válida hasta:</strong> ' . e($expiresLabel) . '</p>' : '')
+            . ($invoice ? '<p>Adjuntamos tu factura <strong>N° ' . e($invoice->number) . '</strong>. También puedes descargarla desde tu panel, en la sección <em>Licencia</em>.</p>' : '')
+            . '<p>¡Gracias por seguir con nosotros!</p>';
+
+        if ($clientEmail && AdminNotifier::clientEnabled()) {
+            try {
+                if ($invoice) {
+                    \Illuminate\Support\Facades\Mail::to($clientEmail)->sendNow(new \App\Mail\SubscriptionInvoiceMail(
+                        '✅ Tu factura de DipleBill (' . $invoice->number . ')',
+                        $bodyHtml,
+                        \App\Services\SubscriptionInvoiceService::renderPdf($invoice),
+                        \App\Services\SubscriptionInvoiceService::filename($invoice)
+                    ));
+                } else {
+                    AdminNotifier::notifyClient($clientEmail, '✅ Tu renovación fue aprobada — DipleBill', $bodyHtml);
+                }
+            } catch (\Throwable $e) {
+                \Illuminate\Support\Facades\Log::warning('No se pudo enviar la factura al cliente: ' . $e->getMessage());
+            }
+        }
         AdminNotifier::notifyRoot(
             'renewal',
             '🔁 Licencia renovada: ' . $organization->name,

--- a/app/Http/Controllers/Api/V1/PlanController.php
+++ b/app/Http/Controllers/Api/V1/PlanController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
-use App\Models\GlobalSetting;
 use App\Models\Organization;
 use App\Models\Plan;
 use App\Services\PlanLimits;
@@ -34,9 +33,6 @@ class PlanController extends Controller
             'is_lifetime' => (bool) $organization->is_lifetime,
             'license_expires_at' => $organization->license_expires_at,
             'usage' => PlanLimits::for($organization)->usage(),
-            // Datos de contacto para renovar/mejorar (mientras no haya pasarela).
-            'payment_account' => GlobalSetting::where('key', 'payment_account')->value('value') ?? '',
-            'payment_whatsapp' => GlobalSetting::where('key', 'payment_whatsapp')->value('value') ?? '',
         ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/SubscriptionInvoiceController.php
+++ b/app/Http/Controllers/Api/V1/SubscriptionInvoiceController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\SubscriptionInvoice;
+use App\Services\SubscriptionInvoiceService;
+use Illuminate\Support\Facades\Auth;
+
+class SubscriptionInvoiceController extends Controller
+{
+    /** Facturas de suscripción emitidas a la organización del cliente. */
+    public function index()
+    {
+        $orgId = Auth::user()->organization_id;
+
+        $invoices = SubscriptionInvoice::where('organization_id', $orgId)
+            ->orderByDesc('issued_at')
+            ->get()
+            ->map(fn ($i) => [
+                'id'           => $i->id,
+                'number'       => $i->number,
+                'concept'      => $i->concept,
+                'amount'       => $i->amount,
+                'currency'     => $i->currency,
+                'issued_at'    => $i->issued_at,
+                'period_start' => $i->period_start,
+                'period_end'   => $i->period_end,
+            ]);
+
+        return response()->json(['data' => $invoices]);
+    }
+
+    /** Descarga el PDF de una factura propia. */
+    public function download($id)
+    {
+        $orgId = Auth::user()->organization_id;
+
+        $invoice = SubscriptionInvoice::where('id', $id)
+            ->where('organization_id', $orgId)
+            ->firstOrFail();
+
+        return response(SubscriptionInvoiceService::renderPdf($invoice), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="' . SubscriptionInvoiceService::filename($invoice) . '"',
+        ]);
+    }
+}

--- a/app/Http/Middleware/TenantDatabaseSwitcher.php
+++ b/app/Http/Middleware/TenantDatabaseSwitcher.php
@@ -37,9 +37,6 @@ class TenantDatabaseSwitcher
                             'message' => 'Tu licencia de uso ha expirado.',
                             'error_code' => 'LICENSE_EXPIRED',
                             'support_message' => $supportMessage,
-                            // Datos de pago para que el cliente pueda renovar sin salir de la app.
-                            'payment_account' => GlobalSetting::where('key', 'payment_account')->value('value') ?? '',
-                            'payment_whatsapp' => GlobalSetting::where('key', 'payment_whatsapp')->value('value') ?? '',
                         ], Response::HTTP_PAYMENT_REQUIRED);
                     }
                 }

--- a/app/Mail/DynamicSystemMail.php
+++ b/app/Mail/DynamicSystemMail.php
@@ -3,11 +3,12 @@
 namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class DynamicSystemMail extends Mailable implements ShouldQueue
+// Envío síncrono a propósito: los correos del sistema (avisos, comprobantes,
+// pruebas de SMTP) deben salir en el momento, sin depender de un worker de cola.
+class DynamicSystemMail extends Mailable
 {
     use Queueable, SerializesModels;
 

--- a/app/Mail/LicenseExpiringMail.php
+++ b/app/Mail/LicenseExpiringMail.php
@@ -13,8 +13,7 @@ class LicenseExpiringMail extends Mailable
     public function __construct(
         public string $name,
         public int $daysLeft,
-        public string $expiresAt,
-        public array $paymentInfo
+        public string $expiresAt
     ) {
     }
 
@@ -24,20 +23,9 @@ class LicenseExpiringMail extends Mailable
             ? 'Tu licencia de DipleBill vence mañana'
             : "Tu licencia de DipleBill vence en {$this->daysLeft} días";
 
-        $account = $this->paymentInfo['account'] ?? '';
-        $whatsapp = $this->paymentInfo['whatsapp'] ?? '';
-        $whatsappBlock = $whatsapp
-            ? "<p>Escríbenos por WhatsApp al <strong>{$whatsapp}</strong> para renovar en minutos.</p>"
-            : '';
-        $accountBlock = $account
-            ? "<p>Cuenta para transferencia: <strong>{$account}</strong></p>"
-            : '';
-
         $body = "<p>Hola <strong>{$this->name}</strong>,</p>
         <p>Tu licencia de DipleBill vence el <strong>{$this->expiresAt}</strong> (en {$this->daysLeft} día(s)).</p>
-        <p>Para no interrumpir tu facturación, renueva antes de esa fecha:</p>
-        {$accountBlock}
-        {$whatsappBlock}
+        <p>Para no interrumpir tu facturación, renueva desde tu panel en la sección <strong>Licencia</strong>: ahí encontrarás los métodos de pago disponibles y podrás subir tu comprobante.</p>
         <p style='color: #6b7280; font-size: 14px;'>Al vencer, el acceso se pausa pero tus datos se conservan y vuelven a estar disponibles al renovar.</p>
         <p>Atentamente,<br>El equipo de DipleBill</p>";
 

--- a/app/Mail/SubscriptionInvoiceMail.php
+++ b/app/Mail/SubscriptionInvoiceMail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Correo de confirmación de renovación con la factura de DipleBill adjunta (PDF).
+ */
+class SubscriptionInvoiceMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public string $subjectLine,
+        public string $bodyHtml,
+        public string $pdfBytes,
+        public string $filename
+    ) {
+    }
+
+    public function build()
+    {
+        return $this->subject($this->subjectLine)
+            ->view('emails.system')
+            ->with([
+                'subject' => $this->subjectLine,
+                'body' => $this->bodyHtml,
+            ])
+            ->attachData($this->pdfBytes, $this->filename, ['mime' => 'application/pdf']);
+    }
+}

--- a/app/Models/SubscriptionInvoice.php
+++ b/app/Models/SubscriptionInvoice.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Model;
+
+class SubscriptionInvoice extends Model
+{
+    use Uuids;
+
+    protected $connection = 'central';
+    protected $table = 'subscription_invoices';
+
+    protected $fillable = [
+        'number',
+        'organization_id',
+        'payment_submission_id',
+        'plan_id',
+        'concept',
+        'period_start',
+        'period_end',
+        'amount',
+        'currency',
+        'payment_method',
+        'reference',
+        'issuer',
+        'customer',
+        'issued_at',
+        'issued_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'float',
+            'period_start' => 'date',
+            'period_end' => 'date',
+            'issued_at' => 'datetime',
+            'issuer' => 'array',
+            'customer' => 'array',
+        ];
+    }
+
+    public function organization()
+    {
+        return $this->belongsTo(Organization::class);
+    }
+}

--- a/app/Services/AdminNotifier.php
+++ b/app/Services/AdminNotifier.php
@@ -96,6 +96,9 @@ class AdminNotifier
     private static function deliver(string $email, string $subject, string $bodyHtml, string $audience): void
     {
         try {
+            // Usar el SMTP configurado en el panel (no el MAIL_* del .env, que por
+            // defecto es 'log'). Si no hay SMTP válido, cae a 'log' sin romper.
+            MailConfigurator::applyConfiguration();
             Mail::to($email)->sendNow(new DynamicSystemMail($subject, $bodyHtml));
         } catch (\Throwable $e) {
             Log::warning("AdminNotifier[$audience] falló para {$email}: " . $e->getMessage());

--- a/app/Services/SubscriptionInvoiceService.php
+++ b/app/Services/SubscriptionInvoiceService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\GlobalSetting;
+use App\Models\Organization;
+use App\Models\Plan;
+use App\Models\PaymentSubmission;
+use App\Models\SubscriptionInvoice;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Emite y renderiza las facturas de suscripción de DipleBill hacia el cliente.
+ * La factura guarda un snapshot inmutable del emisor y del cliente, y el PDF se
+ * genera bajo demanda desde ese snapshot (no depende de archivos en disco, así
+ * sobrevive a redeploys del contenedor).
+ */
+class SubscriptionInvoiceService
+{
+    /** Datos del emisor (tu empresa), editables en Configuración Global, con valores por defecto. */
+    public static function issuerData(): array
+    {
+        $get = fn (string $key, string $default = '') => GlobalSetting::where('key', $key)->value('value') ?: $default;
+
+        return [
+            'name'        => $get('company_legal_name', 'DipleBill'),
+            'ruc'         => $get('company_ruc', ''),
+            'address'     => $get('company_address', ''),
+            'phone'       => $get('company_phone', ''),
+            'email'       => $get('company_email', ''),
+            'website'     => $get('company_website', ''),
+        ];
+    }
+
+    /** Genera el siguiente número correlativo del año: DB-2026-0001. */
+    public static function nextNumber(\DateTimeInterface $issuedAt): string
+    {
+        $year = (int) $issuedAt->format('Y');
+        $prefix = "DB-{$year}-";
+
+        $last = SubscriptionInvoice::where('number', 'like', $prefix . '%')
+            ->orderByDesc('number')
+            ->value('number');
+
+        $seq = $last ? ((int) substr($last, strlen($prefix))) + 1 : 1;
+
+        return $prefix . str_pad((string) $seq, 4, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Crea la factura a partir de un comprobante aprobado.
+     * Idempotente: si ya existe factura para ese comprobante, la devuelve.
+     */
+    public static function createFromSubmission(
+        PaymentSubmission $submission,
+        Organization $organization,
+        ?Plan $plan,
+        ?\DateTimeInterface $periodStart,
+        ?\DateTimeInterface $periodEnd,
+        ?string $adminId
+    ): SubscriptionInvoice {
+        $existing = SubscriptionInvoice::where('payment_submission_id', $submission->id)->first();
+        if ($existing) {
+            return $existing;
+        }
+
+        return DB::connection('central')->transaction(function () use ($submission, $organization, $plan, $periodStart, $periodEnd, $adminId) {
+            $issuedAt = now();
+
+            $concept = $plan
+                ? "Suscripción DipleBill — {$plan->name}"
+                : 'Renovación de suscripción DipleBill';
+
+            $customer = [
+                'name'    => $organization->name,
+                'contact' => $organization->user?->name ?? '',
+                'email'   => $organization->user?->email ?? $organization->email ?? '',
+                'phone'   => $organization->phone ?? '',
+                'address' => $organization->address ?? '',
+            ];
+
+            return SubscriptionInvoice::create([
+                'number'                => self::nextNumber($issuedAt),
+                'organization_id'       => $organization->id,
+                'payment_submission_id' => $submission->id,
+                'plan_id'               => $plan?->id,
+                'concept'               => $concept,
+                'period_start'          => $periodStart,
+                'period_end'            => $periodEnd,
+                'amount'                => $submission->amount,
+                'currency'              => $submission->currency ?? ($plan?->currency ?? 'NIO'),
+                'payment_method'        => $submission->provider?->name ?? 'Transferencia',
+                'reference'             => $submission->reference,
+                'issuer'                => self::issuerData(),
+                'customer'              => $customer,
+                'issued_at'             => $issuedAt,
+                'issued_by'             => $adminId,
+            ]);
+        });
+    }
+
+    /** Renderiza el PDF de la factura (bytes) desde su snapshot. */
+    public static function renderPdf(SubscriptionInvoice $invoice): string
+    {
+        return Pdf::loadView('invoices.subscription', ['invoice' => $invoice])
+            ->setPaper('letter')
+            ->output();
+    }
+
+    /** Nombre de archivo sugerido para la descarga. */
+    public static function filename(SubscriptionInvoice $invoice): string
+    {
+        return 'Factura-' . $invoice->number . '.pdf';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,9 @@
     },
     "extra": {
         "laravel": {
-            "dont-discover": []
+            "dont-discover": [
+                "laravel/telescope"
+            ]
         }
     },
     "config": {

--- a/database/migrations/2026_07_20_120000_create_subscription_invoices_table.php
+++ b/database/migrations/2026_07_20_120000_create_subscription_invoices_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection('central')->create('subscription_invoices', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('number')->unique();                 // DB-2026-0001
+            $table->uuid('organization_id')->index();
+            $table->uuid('payment_submission_id')->nullable()->index();
+            $table->uuid('plan_id')->nullable();
+
+            $table->string('concept');                          // "Plan Pro (6 meses) — Suscripción DipleBill"
+            $table->date('period_start')->nullable();           // inicio de la licencia cubierta
+            $table->date('period_end')->nullable();             // fin de la licencia cubierta
+
+            $table->decimal('amount', 12, 2);
+            $table->string('currency', 8)->default('NIO');
+            $table->string('payment_method')->nullable();       // nombre del método (transferencia)
+            $table->string('reference')->nullable();            // N° de transferencia
+
+            // Snapshots inmutables: la factura no cambia aunque cambien la org, el plan o los datos de la empresa.
+            $table->json('issuer');                             // datos de DipleBill al momento de emitir
+            $table->json('customer');                           // datos del cliente al momento de emitir
+
+            $table->timestamp('issued_at');
+            $table->uuid('issued_by')->nullable();              // admin que aprobó
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('central')->dropIfExists('subscription_invoices');
+    }
+};

--- a/database/seeders/PaymentProvidersSeeder.php
+++ b/database/seeders/PaymentProvidersSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\GlobalSetting;
 use App\Models\PaymentProvider;
 use Illuminate\Database\Seeder;
 
@@ -11,9 +10,7 @@ class PaymentProvidersSeeder extends Seeder
     public function run(): void
     {
         // Método por defecto: transferencia bancaria con validación por comprobante.
-        // Toma la cuenta ya configurada en settings si existe.
-        $account = GlobalSetting::where('key', 'payment_account')->value('value');
-
+        // El admin edita las instrucciones reales en Pagos → Métodos de pago.
         PaymentProvider::firstOrCreate(
             ['driver' => 'transfer'],
             [
@@ -22,9 +19,7 @@ class PaymentProvidersSeeder extends Seeder
                 'is_default' => true,
                 'mode' => 'live',
                 'supports_receipt' => true,
-                'instructions' => $account
-                    ? "Realiza tu pago a: {$account}\nLuego sube el comprobante para validar tu renovación."
-                    : "Realiza tu transferencia y sube el comprobante para validar tu renovación.",
+                'instructions' => 'Realiza tu transferencia y sube el comprobante para validar tu renovación.',
             ]
         );
     }

--- a/docker/DEPLOY.md
+++ b/docker/DEPLOY.md
@@ -1,0 +1,106 @@
+# Despliegue en Dokploy — Backend DipleBill
+
+Guía operativa para el servicio **Backend** (contenedor del `Dockerfile`). La app
+**Database** (MySQL) corre en su propio servicio/contenedor.
+
+El contenedor ya hace, en el arranque (`docker/entrypoint.sh`):
+`storage:link` → `tenants:migrate` (central + tenants dedicados) → `config/route/view:cache` → `supervisord`.
+Y `supervisord` levanta: **nginx**, **php-fpm** y **scheduler** (`schedule:work`, para backups y avisos).
+
+---
+
+## 1. Volumen persistente (OBLIGATORIO)
+
+Sin esto, cada redeploy **borra comprobantes de pago, capturas de reportes y backups locales**.
+
+En Dokploy → servicio Backend → **Volumes / Mounts**, montar un volumen en:
+
+```
+/var/www/storage
+```
+
+> El entrypoint recrea `storage/framework/*` si el volumen viene vacío, así que
+> montar todo `storage` es seguro. Si prefieres granular, monta al menos
+> `/var/www/storage/app`.
+
+## 2. Variables de entorno (Environment)
+
+Mínimas de producción:
+
+```
+APP_ENV=production
+APP_DEBUG=false
+APP_KEY=base64:...            # generar una vez: php artisan key:generate --show
+APP_URL=https://api.tudominio.com
+APP_TIMEZONE=America/Managua
+
+DB_CONNECTION=mysql
+DB_HOST=<host del servicio Database en Dokploy>
+DB_PORT=3306
+DB_DATABASE=...
+DB_USERNAME=...
+DB_PASSWORD=...
+
+# mysqldump vive en el contenedor (default-mysql-client). Dejar VACÍO.
+DB_DUMP_BINARY_PATH=
+
+QUEUE_CONNECTION=sync         # los correos del sistema van con sendNow; sin worker
+SESSION_DRIVER=database
+CACHE_STORE=database
+
+# SMTP real (o configúralo desde el panel /admin/email-settings)
+MAIL_MAILER=smtp
+MAIL_HOST=...
+MAIL_PORT=587
+MAIL_USERNAME=...
+MAIL_PASSWORD=...
+MAIL_ENCRYPTION=tls
+MAIL_FROM_ADDRESS=no-reply@tudominio.com
+MAIL_FROM_NAME=DipleBill
+
+# Backups off-site (S3 / Backblaze B2 / DO Spaces)
+BACKUP_DISK=s3
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_BUCKET=...
+AWS_DEFAULT_REGION=...
+# B2/Spaces: además
+# AWS_ENDPOINT=https://s3.us-west-000.backblazeb2.com
+# AWS_USE_PATH_STYLE_ENDPOINT=true
+
+SENTRY_LARAVEL_DSN=...        # opcional, monitoreo
+TELESCOPE_ENABLED=false
+```
+
+## 3. CORS
+
+Asegurar que `config/cors.php` (o `CORS_ALLOWED_ORIGINS`) incluya los dominios reales
+de la app del negocio y del POS, si no las llamadas del navegador fallarán.
+
+## 4. Deploy
+
+Dokploy reconstruye la imagen desde el `Dockerfile` en cada deploy. Al reconstruir:
+las migraciones (incl. tenants) corren solas en el entrypoint. No hace falta paso manual.
+
+## 5. Verificación post-deploy
+
+En la terminal del contenedor Backend:
+
+```sh
+which mysqldump && mysqldump --version     # cliente MySQL presente
+php artisan schedule:list                  # tareas agendadas visibles
+ls -la storage/app/public                  # storage:link OK
+php artisan backup:run --only-db           # genera un backup...
+php artisan backup:list                    # ...y aparece en el disco s3
+```
+
+## 6. Prueba de RESTORE (no basta con generar el backup)
+
+Al menos una vez antes del lanzamiento:
+
+1. Descargar el `.zip` más reciente del bucket.
+2. Descomprimir → contiene el `.sql` de la base.
+3. Restaurar en una BD de prueba: `mysql -u user -p test_db < db-dumps/mysql-*.sql`
+4. Verificar que las tablas y datos están completos.
+
+> Un backup que nunca se probó restaurando **no es un backup**.

--- a/docker/DEPLOY.md
+++ b/docker/DEPLOY.md
@@ -72,10 +72,17 @@ SENTRY_LARAVEL_DSN=...        # opcional, monitoreo
 TELESCOPE_ENABLED=false
 ```
 
-## 3. CORS
+## 3. CORS — no requiere acción
 
-Asegurar que `config/cors.php` (o `CORS_ALLOWED_ORIGINS`) incluya los dominios reales
-de la app del negocio y del POS, si no las llamadas del navegador fallarán.
+El proyecto no publica `config/cors.php`, así que usa el default de Laravel:
+`allowed_origins => ['*']` en las rutas `api/*` con `supports_credentials => false`.
+Como las apps se autentican con **token Bearer** (no cookies), `*` funciona para
+cualquier dominio y ninguna llamada del navegador falla por CORS — da igual que la
+web y la app estén en dominios distintos. **No hay que tocar nada.**
+
+> Buena práctica (opcional, a futuro): publicar `config/cors.php`
+> (`php artisan config:publish cors`) y listar los dominios exactos en
+> `allowed_origins`. No es necesario para el lanzamiento.
 
 ## 4. Deploy
 
@@ -84,15 +91,23 @@ las migraciones (incl. tenants) corren solas en el entrypoint. No hace falta pas
 
 ## 5. Verificación post-deploy
 
-En la terminal del contenedor Backend:
+**Todo se corre en el contenedor Backend** (Dokploy → servicio Backend → Terminal),
+NO en el de MySQL. `mysqldump` es el *cliente* instalado en la imagen del Backend;
+se conecta por red al servicio MySQL usando `DB_HOST`. Como la BD está en otro
+servicio/proyecto, `DB_HOST` debe ser el hostname interno de ese servicio en la red
+de Dokploy (o el host:puerto expuesto), y ambos deben compartir red.
 
 ```sh
-which mysqldump && mysqldump --version     # cliente MySQL presente
+which mysqldump && mysqldump --version     # cliente MySQL presente en el Backend
+php artisan tinker --execute="DB::select('select 1');"   # el Backend alcanza la BD
 php artisan schedule:list                  # tareas agendadas visibles
 ls -la storage/app/public                  # storage:link OK
-php artisan backup:run --only-db           # genera un backup...
+php artisan backup:run --only-db           # dumpea la BD remota vía mysqldump...
 php artisan backup:list                    # ...y aparece en el disco s3
 ```
+
+> Si `backup:run` falla con "connection refused" o "unknown host", es que el
+> Backend no alcanza el MySQL: revisa `DB_HOST`/red compartida entre servicios.
 
 ## 6. Prueba de RESTORE (no basta con generar el backup)
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Arranque del contenedor de producción (Dokploy).
+# Se ejecuta antes de supervisord: prepara el estado que un contenedor efímero
+# no trae por sí solo. Cualquier paso opcional no debe tumbar el arranque.
+set -e
+
+cd /var/www
+
+echo "[entrypoint] Preparando almacenamiento..."
+# Asegurar la estructura de storage cuando se monta un volumen vacío.
+mkdir -p storage/framework/cache/data \
+         storage/framework/sessions \
+         storage/framework/views \
+         storage/app/public \
+         storage/logs \
+         bootstrap/cache
+chown -R www-data:www-data storage bootstrap/cache || true
+
+# Enlace público (logos, imágenes de productos, assets); idempotente.
+php artisan storage:link || true
+
+echo "[entrypoint] Corriendo migraciones (central + tenants dedicados)..."
+# tenants:migrate ya pasa --force internamente. No debe abortar el arranque si
+# la BD tarda unos segundos en aceptar conexiones.
+php artisan tenants:migrate || echo "[entrypoint] AVISO: tenants:migrate falló; revisa la BD."
+
+echo "[entrypoint] Cacheando configuración..."
+php artisan config:cache || true
+php artisan route:cache || true
+php artisan view:cache || true
+
+echo "[entrypoint] Listo. Iniciando supervisord."
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/docker/nginx/conf.d/app.conf
+++ b/docker/nginx/conf.d/app.conf
@@ -4,7 +4,11 @@ server {
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     root /var/www/public;
-    
+
+    # Debe ser >= post_max_size de PHP (12M). Sin esto nginx rechaza (413) las
+    # subidas de comprobantes/capturas con el default de 1 MB.
+    client_max_body_size 12m;
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/docker/php/uploads.ini
+++ b/docker/php/uploads.ini
@@ -1,0 +1,7 @@
+; Límites de subida para comprobantes de pago y capturas de reportes de error.
+; La app valida hasta 5–8 MB; dejamos margen. Debe ir en línea con
+; client_max_body_size de nginx (12m).
+upload_max_filesize = 10M
+post_max_size = 12M
+memory_limit = 256M
+max_execution_time = 120

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -14,3 +14,16 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+; Corre las tareas programadas (backups spatie, avisos de vencimiento de
+; licencia, backup:clean). Sin este proceso NADA de lo agendado se ejecuta en
+; producción. schedule:work despierta cada minuto y lanza lo que toque.
+[program:scheduler]
+command=php /var/www/artisan schedule:work
+user=www-data
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -98,6 +98,7 @@
             <th style="padding:10px 12px; border-bottom:1px solid var(--border-color);">Monto</th>
             <th style="padding:10px 12px; border-bottom:1px solid var(--border-color);">Estado</th>
             <th style="padding:10px 12px; border-bottom:1px solid var(--border-color);">Revisado</th>
+            <th style="padding:10px 12px; border-bottom:1px solid var(--border-color);">Factura</th>
         </tr></thead>
         <tbody>
             @foreach($recent as $s)
@@ -109,6 +110,13 @@
                     <span style="font-size:11px; padding:2px 8px; border-radius:6px; {{ $s->status === 'approved' ? 'background:rgba(16,185,129,0.12); color:#34D399;' : 'background:rgba(239,68,68,0.12); color:#f87171;' }}">{{ $s->status === 'approved' ? 'Aprobado' : 'Rechazado' }}</span>
                 </td>
                 <td style="padding:10px 12px; border-bottom:1px solid var(--border-color); color:var(--text-secondary);">{{ $s->reviewed_at?->format('d/m/Y H:i') }}</td>
+                <td style="padding:10px 12px; border-bottom:1px solid var(--border-color);">
+                    @if($s->status === 'approved')
+                        <a href="{{ route('admin.payments.invoice', $s->id) }}" target="_blank" style="color:#818CF8; text-decoration:none; font-weight:600;">Ver factura ↗</a>
+                    @else
+                        <span style="color:var(--text-secondary);">—</span>
+                    @endif
+                </td>
             </tr>
             @endforeach
         </tbody>

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -72,32 +72,46 @@
             />
         </div>
 
-        <h2 style="font-size: 16px; font-weight: 600; margin-top: 36px; margin-bottom: 24px; color: var(--text-primary); border-bottom: 1px solid var(--border-color); padding-bottom: 12px;">Datos de Pago (Renovación de Licencias)</h2>
+        <h2 style="font-size: 16px; font-weight: 600; margin-top: 36px; margin-bottom: 24px; color: var(--text-primary); border-bottom: 1px solid var(--border-color); padding-bottom: 12px;">Datos del emisor (Facturas de suscripción)</h2>
 
         <p style="font-size: 13px; color: var(--text-secondary); margin-bottom: 20px;">
-            Estos datos se muestran a los clientes en la pantalla de licencia vencida, en su panel de licencia y en los correos de aviso de vencimiento, para que puedan renovar.
+            Estos datos aparecen como emisor en la factura PDF que se genera y se envía al cliente cuando apruebas su comprobante de pago.
         </p>
 
-        <div style="margin-bottom: 20px;">
-            <label style="display: block; font-size: 13px; font-weight: 500; color: var(--text-primary); margin-bottom: 8px;">Cuenta para transferencia</label>
-            <input
-                type="text"
-                name="payment_account"
-                value="{{ old('payment_account', $paymentAccount) }}"
-                style="width: 100%; background: rgba(255,255,255,0.03); border: 1px solid var(--border-color); border-radius: 8px; padding: 10px 12px; font-size: 14px; color: var(--text-primary); outline: none;"
-                placeholder="Ej. BAC Córdobas 123456789 a nombre de DipleBill"
-            />
+        @php
+            $fld = 'width: 100%; background: rgba(255,255,255,0.03); border: 1px solid var(--border-color); border-radius: 8px; padding: 10px 12px; font-size: 14px; color: var(--text-primary); outline: none;';
+            $lbl = 'display: block; font-size: 13px; font-weight: 500; color: var(--text-primary); margin-bottom: 8px;';
+        @endphp
+
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-bottom:20px;">
+            <div>
+                <label style="{{ $lbl }}">Razón social / Nombre</label>
+                <input type="text" name="company_legal_name" value="{{ old('company_legal_name', $company['company_legal_name']) }}" style="{{ $fld }}" placeholder="Ej. DipleBill S.A.">
+            </div>
+            <div>
+                <label style="{{ $lbl }}">RUC / N° fiscal</label>
+                <input type="text" name="company_ruc" value="{{ old('company_ruc', $company['company_ruc']) }}" style="{{ $fld }}" placeholder="Ej. J0310000000000">
+            </div>
         </div>
 
-        <div style="margin-bottom: 28px;">
-            <label style="display: block; font-size: 13px; font-weight: 500; color: var(--text-primary); margin-bottom: 8px;">WhatsApp de pagos</label>
-            <input
-                type="text"
-                name="payment_whatsapp"
-                value="{{ old('payment_whatsapp', $paymentWhatsapp) }}"
-                style="width: 100%; background: rgba(255,255,255,0.03); border: 1px solid var(--border-color); border-radius: 8px; padding: 10px 12px; font-size: 14px; color: var(--text-primary); outline: none;"
-                placeholder="Ej. +505 8899 7391"
-            />
+        <div style="margin-bottom:20px;">
+            <label style="{{ $lbl }}">Dirección</label>
+            <input type="text" name="company_address" value="{{ old('company_address', $company['company_address']) }}" style="{{ $fld }}" placeholder="Ej. Managua, Nicaragua">
+        </div>
+
+        <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:16px; margin-bottom:28px;">
+            <div>
+                <label style="{{ $lbl }}">Teléfono</label>
+                <input type="text" name="company_phone" value="{{ old('company_phone', $company['company_phone']) }}" style="{{ $fld }}" placeholder="+505 ...">
+            </div>
+            <div>
+                <label style="{{ $lbl }}">Correo</label>
+                <input type="email" name="company_email" value="{{ old('company_email', $company['company_email']) }}" style="{{ $fld }}" placeholder="facturacion@diplebill.com">
+            </div>
+            <div>
+                <label style="{{ $lbl }}">Sitio web</label>
+                <input type="text" name="company_website" value="{{ old('company_website', $company['company_website']) }}" style="{{ $fld }}" placeholder="www.diplebill.com">
+            </div>
         </div>
 
         <button type="submit" style="background: rgba(99, 102, 241, 0.1); color: #818CF8; border: 1px solid rgba(99, 102, 241, 0.4); padding: 12px 24px; border-radius: 10px; font-weight: 600; cursor: pointer; transition: all 0.2s ease;">

--- a/resources/views/invoices/subscription.blade.php
+++ b/resources/views/invoices/subscription.blade.php
@@ -1,0 +1,130 @@
+@php
+    $cur = $invoice->currency === 'USD' ? 'US$' : ($invoice->currency === 'NIO' ? 'C$' : $invoice->currency . ' ');
+    $money = fn ($n) => $cur . number_format((float) $n, 2);
+    $issuer = $invoice->issuer ?? [];
+    $customer = $invoice->customer ?? [];
+@endphp
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <style>
+        * { box-sizing: border-box; }
+        body { font-family: DejaVu Sans, sans-serif; color: #1f2937; font-size: 12px; margin: 0; }
+        .wrap { padding: 36px 44px; }
+        .top { width: 100%; }
+        .top td { vertical-align: top; }
+        .brand { font-size: 24px; font-weight: bold; color: #4f46e5; }
+        .brand small { display: block; font-size: 11px; color: #6b7280; font-weight: normal; margin-top: 2px; }
+        .doc-title { text-align: right; }
+        .doc-title h1 { font-size: 20px; margin: 0; color: #111827; letter-spacing: 1px; }
+        .doc-title .num { font-size: 13px; color: #4f46e5; font-weight: bold; margin-top: 4px; }
+        .doc-title .date { font-size: 11px; color: #6b7280; margin-top: 2px; }
+        .muted { color: #6b7280; }
+        .parties { width: 100%; margin-top: 28px; }
+        .parties td { width: 50%; vertical-align: top; padding-right: 16px; }
+        .label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: #9ca3af; font-weight: bold; margin-bottom: 4px; }
+        .party strong { font-size: 13px; color: #111827; }
+        .party div { margin-top: 1px; }
+        table.items { width: 100%; border-collapse: collapse; margin-top: 30px; }
+        table.items th { background: #111827; color: #fff; text-align: left; padding: 9px 12px; font-size: 11px; }
+        table.items th.r, table.items td.r { text-align: right; }
+        table.items td { padding: 12px; border-bottom: 1px solid #e5e7eb; }
+        .period { font-size: 11px; color: #6b7280; margin-top: 4px; }
+        .totals { width: 100%; margin-top: 14px; }
+        .totals td { padding: 4px 12px; }
+        .totals .k { text-align: right; color: #6b7280; }
+        .totals .v { text-align: right; width: 130px; }
+        .totals .grand td { border-top: 2px solid #111827; font-size: 15px; font-weight: bold; color: #111827; padding-top: 10px; }
+        .pay { margin-top: 30px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 14px 16px; font-size: 11px; }
+        .pay .label { margin-bottom: 6px; }
+        .paid { display: inline-block; margin-top: 6px; color: #059669; border: 1px solid #059669; border-radius: 4px; padding: 3px 10px; font-weight: bold; font-size: 12px; }
+        .foot { margin-top: 40px; text-align: center; color: #9ca3af; font-size: 10px; border-top: 1px solid #e5e7eb; padding-top: 12px; }
+    </style>
+</head>
+<body>
+<div class="wrap">
+    <table class="top">
+        <tr>
+            <td>
+                <div class="brand">{{ $issuer['name'] ?? 'DipleBill' }}
+                    <small>
+                        @if(!empty($issuer['ruc'])) RUC: {{ $issuer['ruc'] }}<br>@endif
+                        @if(!empty($issuer['address'])) {{ $issuer['address'] }}<br>@endif
+                        @if(!empty($issuer['phone'])) Tel: {{ $issuer['phone'] }}@endif
+                        @if(!empty($issuer['email'])) · {{ $issuer['email'] }}@endif
+                    </small>
+                </div>
+            </td>
+            <td class="doc-title">
+                <h1>FACTURA</h1>
+                <div class="num">N° {{ $invoice->number }}</div>
+                <div class="date">Fecha de emisión: {{ $invoice->issued_at?->format('d/m/Y') }}</div>
+            </td>
+        </tr>
+    </table>
+
+    <table class="parties">
+        <tr>
+            <td class="party">
+                <div class="label">Facturado a</div>
+                <strong>{{ $customer['name'] ?? '—' }}</strong>
+                @if(!empty($customer['contact']))<div>{{ $customer['contact'] }}</div>@endif
+                @if(!empty($customer['email']))<div class="muted">{{ $customer['email'] }}</div>@endif
+                @if(!empty($customer['phone']))<div class="muted">Tel: {{ $customer['phone'] }}</div>@endif
+                @if(!empty($customer['address']))<div class="muted">{{ $customer['address'] }}</div>@endif
+            </td>
+            <td class="party">
+                <div class="label">Detalles</div>
+                <div><span class="muted">Método de pago:</span> {{ $invoice->payment_method ?? 'Transferencia' }}</div>
+                @if($invoice->reference)<div><span class="muted">Referencia:</span> {{ $invoice->reference }}</div>@endif
+                <div><span class="muted">Moneda:</span> {{ $invoice->currency }}</div>
+            </td>
+        </tr>
+    </table>
+
+    <table class="items">
+        <thead>
+            <tr>
+                <th>Descripción</th>
+                <th class="r">Importe</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    {{ $invoice->concept }}
+                    @if($invoice->period_start && $invoice->period_end)
+                        <div class="period">Período de suscripción: {{ $invoice->period_start->format('d/m/Y') }} — {{ $invoice->period_end->format('d/m/Y') }}</div>
+                    @endif
+                </td>
+                <td class="r">{{ $money($invoice->amount) }}</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <table class="totals">
+        <tr>
+            <td class="k">Subtotal</td>
+            <td class="v">{{ $money($invoice->amount) }}</td>
+        </tr>
+        <tr class="grand">
+            <td class="k">Total</td>
+            <td class="v">{{ $money($invoice->amount) }}</td>
+        </tr>
+    </table>
+
+    <div class="pay">
+        <div class="label">Estado del pago</div>
+        Pago recibido y validado por {{ $issuer['name'] ?? 'DipleBill' }}.
+        <div><span class="paid">PAGADO</span></div>
+    </div>
+
+    <div class="foot">
+        Gracias por confiar en {{ $issuer['name'] ?? 'DipleBill' }}.
+        @if(!empty($issuer['website'])) {{ $issuer['website'] }} · @endif
+        Este documento fue generado electrónicamente y es válido sin firma ni sello.
+    </div>
+</div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -156,6 +156,10 @@ Route::prefix('v1')->group(function () {
         Route::get('payments/my-submissions', [\App\Http\Controllers\Api\V1\PaymentController::class, 'mySubmissions']);
         Route::get('payments/{id}/receipt', [\App\Http\Controllers\Api\V1\PaymentController::class, 'downloadReceipt']);
 
+        // Facturas de suscripción emitidas por DipleBill al cliente (descargables).
+        Route::get('subscription-invoices', [\App\Http\Controllers\Api\V1\SubscriptionInvoiceController::class, 'index']);
+        Route::get('subscription-invoices/{id}/download', [\App\Http\Controllers\Api\V1\SubscriptionInvoiceController::class, 'download']);
+
         // Reporte de errores desde la app del negocio (llega al panel root).
         Route::post('error-reports', [\App\Http\Controllers\Api\V1\ErrorReportController::class, 'store']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::prefix('admin')->group(function () {
         Route::post('/payments/providers/{id}/toggle', [AdminPaymentController::class, 'toggleProvider'])->name('admin.payments.providers.toggle');
         Route::post('/payments/providers/{id}/delete', [AdminPaymentController::class, 'destroyProvider'])->name('admin.payments.providers.delete');
         Route::get('/payments/{id}/receipt', [AdminPaymentController::class, 'viewReceipt'])->name('admin.payments.receipt');
+        Route::get('/payments/{id}/invoice', [AdminPaymentController::class, 'downloadInvoice'])->name('admin.payments.invoice');
         Route::post('/payments/{id}/approve', [AdminPaymentController::class, 'approveSubmission'])->name('admin.payments.approve');
         Route::post('/payments/{id}/reject', [AdminPaymentController::class, 'rejectSubmission'])->name('admin.payments.reject');
 


### PR DESCRIPTION
## Resumen
Endurecimiento pre-lanzamiento del backend. Cubre el **Paquete 1** de la auditoría (infra Docker/Dokploy), la función de **facturas de suscripción** y la limpieza/consolidación de correos y datos de pago.

> Nota: incluye el fix de `mysqldump` del PR #22 (este PR lo reemplaza; se puede cerrar #22).

## Infra de producción (Docker/Dokploy)
- **`docker/entrypoint.sh`**: `storage:link` + `tenants:migrate` + `config/route/view:cache` antes de supervisord.
- **supervisord**: nuevo `[program:scheduler]` (`schedule:work`) — sin esto backups y avisos de vencimiento **nunca corren** en producción.
- **Límites de subida**: `docker/php/uploads.ini` (10M/12M) + nginx `client_max_body_size 12m` — arregla el 413 al subir comprobantes.
- **Dockerfile**: `composer install --no-dev` (fuera Telescope/Pint/Sail de prod) + `dont-discover` telescope.
- **`docker/DEPLOY.md`** + `.env.example`: guía de volumen persistente, backups off-site (S3/B2), y prueba de restore.

## Facturas de suscripción (DipleBill → cliente)
- Al aprobar un comprobante se emite una **factura PDF** (dompdf) con snapshot inmutable del emisor/cliente; el cliente la descarga desde su panel y se le envía adjunta por correo. Emisor editable en Configuración Global.
- **Fix**: `AdminPaymentController` usaba `AdminNotifier` sin importarlo → fatal al aprobar/rechazar.

## Correos del sistema
- `DynamicSystemMail` deja de ser `ShouldQueue` → **envío síncrono** (no depende de un worker de cola).
- `AdminNotifier` y `licenses:notify-expiring` aplican el **SMTP configurado en el panel**.
- Aviso de vencimiento ahora es **informativo** (sin datos de pago duplicados); se elimina la sección "Datos de Pago" de Settings y las claves `payment_account/payment_whatsapp`.

## Verificación
- `php -l` en todos los archivos; suite de pruebas del backend; smoke tests de emisión de factura, envío de correos síncronos y `schedule:list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
