### PR TITLE
fix: instalar php-zip en el Dockerfile (arregla el build de producción)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libonig-dev \
     libxml2-dev \
+    libzip-dev \
     zip \
     unzip \
     nginx \
@@ -19,7 +20,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Instalar extensiones de PHP
-RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip
 
 # Límites de subida (comprobantes/capturas). Sobrescribe los defaults de PHP.
 COPY ./docker/php/uploads.ini /usr/local/etc/php/conf.d/zz-uploads.ini

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5824dbb2a986179871488554360be660",
+    "content-hash": "9d0141793113ff1062b9d404484c189f",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",


### PR DESCRIPTION
## Qué arregla
El primer deploy con **Build Type = Dockerfile** falló en `composer install`:

```
phpoffice/phpspreadsheet requires ext-zip -> it is missing from your system
spatie/laravel-backup requires ext-zip ^1.14.0 -> it is missing from your system
```

El Dockerfile no instalaba la extensión **`zip`** de PHP. Nixpacks la detectaba e instalaba sola; el Dockerfile no. La necesitan `spatie/laravel-backup`, `phpoffice/phpspreadsheet` y `maatwebsite/excel`.

## Cambios
- `Dockerfile`: `libzip-dev` en apt-get + `zip` en `docker-php-ext-install`.
- `composer.lock`: refresca el hash tras el cambio de `dont-discover` en `composer.json` (silencia el warning "lock file is not up to date"; sin cambios de versión).

## Después de mergear
Redeploy en Dokploy. El build debe pasar de `composer install` y llegar a
`[entrypoint] Listo. Iniciando supervisord.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
