### PR TITLE
fix: servir Laravel en nginx (quitar sitio default de Debian)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,11 @@ RUN composer install --no-interaction --prefer-dist --optimize-autoloader --no-d
 # Dar permisos a las carpetas de almacenamiento
 RUN chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 
-# Copiar configuración de Nginx
+# Copiar configuración de Nginx. En Debian, 'apt install nginx' deja activo un
+# sitio por defecto (sites-enabled/default) marcado default_server que serviría
+# la página "Welcome to nginx!" en lugar de la app: hay que quitarlo.
 COPY ./docker/nginx/conf.d/app.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/sites-enabled/default
 # Copiar configuración de Supervisor
 COPY ./docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/docker/nginx/conf.d/app.conf
+++ b/docker/nginx/conf.d/app.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 80 default_server;
     index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;


### PR DESCRIPTION
## Qué arregla
Tras el deploy con Dockerfile, `api.diplebill.com` mostraba la página **"Welcome to nginx!"** en lugar de la app Laravel.

**Causa:** en Debian, `apt install nginx` deja activo un sitio por defecto (`/etc/nginx/sites-enabled/default`) marcado `default_server`, que sirve `/var/www/html` (la página de bienvenida). Como nginx incluye tanto `conf.d/*.conf` como `sites-enabled/*`, ese sitio le ganaba a `app.conf` para el dominio.

## Cambios
- `Dockerfile`: `rm -f /etc/nginx/sites-enabled/default` tras copiar la config.
- `app.conf`: `listen 80 default_server;` (root ya apunta a `/var/www/public`).

## Después de mergear
Redeploy. `api.diplebill.com` debe responder ya con la app (p.ej. el JSON/estado de la API o el panel `/admin`), no la página de nginx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
