### PR TITLE
fix: mysqldump sin SSL en backups (cert autofirmado de Dokploy)

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -68,6 +68,11 @@ return [
                 'dump_binary_path' => env('DB_DUMP_BINARY_PATH', ''),
                 'use_single_transaction' => true,
                 'timeout' => 60 * 5,
+                // El cliente MariaDB intenta TLS y verifica el cert; el MySQL de
+                // Dokploy usa uno autofirmado -> "self-signed certificate". El
+                // tráfico es interno de Docker, así que el dump va sin SSL.
+                // Sobreescribible con DB_DUMP_SSL_OPTION="" si el server exige TLS.
+                'add_extra_option' => env('DB_DUMP_SSL_OPTION', '--skip-ssl'),
             ],
         ],
 
@@ -89,6 +94,12 @@ return [
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
+            'dump' => [
+                'dump_binary_path' => env('DB_DUMP_BINARY_PATH', ''),
+                'use_single_transaction' => true,
+                'timeout' => 60 * 5,
+                'add_extra_option' => env('DB_DUMP_SSL_OPTION', '--skip-ssl'),
+            ],
         ],
 
         'mariadb' => [


### PR DESCRIPTION
## Qué arregla
Con `mysqldump` ya instalado (PR #24), el backup fallaba al conectarse:

```
mysqldump: Got error: 2026: "TLS/SSL error: self-signed certificate in certificate chain"
```

El cliente MariaDB intenta TLS y **verifica** el certificado; el MySQL de Dokploy usa uno **autofirmado**, así que la verificación falla. La app (PDO) conecta bien porque no verifica cert (`MYSQL_ATTR_SSL_CA` vacío), pero `mysqldump` es un cliente aparte.

## Cambios
En `config/database.php`, al bloque `dump` de las conexiones `mysql` y `central`:
```php
'add_extra_option' => env('DB_DUMP_SSL_OPTION', '--skip-ssl'),
```
El tráfico Backend↔MySQL es interno de la red de Docker, así que el dump va sin TLS. Configurable con `DB_DUMP_SSL_OPTION` por si el server llegara a exigir TLS.

## Verificado
`mysqldump --skip-ssl` conecta y dumpea la BD en el contenedor.

## Después de mergear
Redeploy → `php artisan backup:run --only-db` debe terminar con "Backup completed!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
