### PR TITLE
fix: dashboard admin no se cae al listar backups (try/catch)

### DIFF
--- a/app/Http/Controllers/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Admin/AdminDashboardController.php
@@ -563,33 +563,42 @@ class AdminDashboardController extends Controller
 
     private function listBackups(): array
     {
-        $disk = \Illuminate\Support\Facades\Storage::disk($this->backupDisk());
-        $dir = $this->backupDir();
+        // Listar backups nunca debe tumbar el dashboard: si el disco no se puede
+        // leer (permisos), la carpeta no existe aún, o el disco (p.ej. s3) está
+        // mal configurado, degradamos a lista vacía en lugar de lanzar un 500.
+        try {
+            $disk = \Illuminate\Support\Facades\Storage::disk($this->backupDisk());
+            $dir = $this->backupDir();
 
-        if (!$disk->exists($dir)) {
+            if (!$disk->exists($dir)) {
+                return [];
+            }
+
+            $files = collect($disk->files($dir))
+                ->filter(fn ($f) => str_ends_with($f, '.zip'))
+                ->sortByDesc(fn ($f) => $disk->lastModified($f))
+                ->values();
+
+            return $files->map(function ($f) use ($disk) {
+                $size = $disk->size($f);
+                if ($size >= 1048576) {
+                    $sizeStr = number_format($size / 1048576, 2) . ' MB';
+                } elseif ($size >= 1024) {
+                    $sizeStr = number_format($size / 1024, 2) . ' KB';
+                } else {
+                    $sizeStr = $size . ' B';
+                }
+                return [
+                    'name' => basename($f),
+                    'size' => $sizeStr,
+                    'created_at' => date('d/m/Y H:i:s', $disk->lastModified($f)),
+                ];
+            })->all();
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::warning('No se pudieron listar los backups: ' . $e->getMessage());
+
             return [];
         }
-
-        $files = collect($disk->files($dir))
-            ->filter(fn ($f) => str_ends_with($f, '.zip'))
-            ->sortByDesc(fn ($f) => $disk->lastModified($f))
-            ->values();
-
-        return $files->map(function ($f) use ($disk) {
-            $size = $disk->size($f);
-            if ($size >= 1048576) {
-                $sizeStr = number_format($size / 1048576, 2) . ' MB';
-            } elseif ($size >= 1024) {
-                $sizeStr = number_format($size / 1024, 2) . ' KB';
-            } else {
-                $sizeStr = $size . ' B';
-            }
-            return [
-                'name' => basename($f),
-                'size' => $sizeStr,
-                'created_at' => date('d/m/Y H:i:s', $disk->lastModified($f)),
-            ];
-        })->all();
     }
 
     public function generateBackup()


### PR DESCRIPTION
## Qué arregla
Al entrar a `/admin/dashboard` (ya autenticado) daba **500**:

```
League\Flysystem\UnableToListContents: DirectoryIterator(/var/www/storage/app/DipleBill): Permission denied
```

`listBackups()` reventaba porque no podía leer la carpeta de backups. En este caso el disparador fue correr `backup:run` como `root` en la terminal (creó `storage/app/DipleBill` con dueño root, y el dashboard corre como www-data). Pero el dashboard **no debería caerse por eso**.

## Cambios
`AdminDashboardController::listBackups()` envuelto en try/catch → degrada a lista vacía y loguea un warning si el disco no se puede leer, la carpeta no existe, o el disco (p.ej. s3) está mal configurado.

## Nota de operación (no código)
El dueño root de `storage/app/DipleBill` se corrige con `chown -R www-data:www-data /var/www/storage`, o solo con redeploy (el entrypoint ya hace ese chown al arrancar). Los backups automáticos corren como www-data vía el scheduler, así que no reaparece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
