### PR TITLE
fix: backup manual en segundo plano (evita 504)

### DIFF
--- a/app/Http/Controllers/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Admin/AdminDashboardController.php
@@ -603,26 +603,27 @@ class AdminDashboardController extends Controller
 
     public function generateBackup()
     {
-        // El dump + zip puede superar el max_execution_time (30s) del request web,
-        // sobre todo con bases de datos grandes. Se eleva el límite solo para esta
-        // acción manual. (El backup automático corre por el scheduler, sin límite.)
-        @set_time_limit(600);
-        @ignore_user_abort(true);
-
+        // El dump + zip de una base grande tarda minutos: correrlo dentro del
+        // request agota el timeout del proxy/nginx (~60s) y devuelve 504 aunque
+        // el backup siga bien. Se lanza en SEGUNDO PLANO (proceso detach, como
+        // www-data) y el request responde al instante; el zip aparece en la
+        // lista al terminar. El backup diario ya corre por el scheduler (CLI).
         try {
-            \Illuminate\Support\Facades\Artisan::call('backup:run', ['--only-db' => true]);
-            $output = \Illuminate\Support\Facades\Artisan::output();
+            $cmd = sprintf(
+                'nohup php %s backup:run --only-db < /dev/null >> %s 2>&1 &',
+                escapeshellarg(base_path('artisan')),
+                escapeshellarg(storage_path('logs/backup.log'))
+            );
 
-            if (stripos($output, 'Backup failed') !== false) {
-                return redirect()->route('admin.dashboard', ['tab' => 'backups'])
-                    ->withErrors(['error' => 'Error al generar la copia de seguridad: ' . $output]);
-            }
+            \Symfony\Component\Process\Process::fromShellCommandline($cmd, base_path())
+                ->setTimeout(15)
+                ->run();
 
             return redirect()->route('admin.dashboard', ['tab' => 'backups'])
-                ->with('success', 'Copia de seguridad de la base de datos generada correctamente.');
-        } catch (\Exception $e) {
+                ->with('success', 'Copia de seguridad iniciada en segundo plano. Aparecerá en la lista en 1–2 minutos según el tamaño de la base; refresca para verla.');
+        } catch (\Throwable $e) {
             return redirect()->route('admin.dashboard', ['tab' => 'backups'])
-                ->withErrors(['error' => 'Error al ejecutar comando de backup: ' . $e->getMessage()]);
+                ->withErrors(['error' => 'No se pudo iniciar el backup: ' . $e->getMessage()]);
         }
     }
 


### PR DESCRIPTION
## Qué arregla
El botón "Generar backup" del panel daba **504 Gateway Time-out**: `generateBackup()` corría `backup:run` **dentro del request HTTP**, y con la base de ~918 MB el dump tarda más que el timeout del proxy/nginx (~60s).

## Cambios
`generateBackup()` ahora lanza el backup como **proceso en segundo plano** (`nohup php artisan backup:run --only-db &`, corriendo como www-data) y el request responde al instante con "backup iniciado". El zip aparece en la lista al terminar (refrescar). Bonus: al correr como www-data, los archivos quedan legibles por el dashboard (sin el problema de permisos de correr como root).

El backup **diario automático** no cambia — sigue por el scheduler (CLI, sin timeout).

## Después de mergear
Redeploy → el botón responde de inmediato; el backup se completa en segundo plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
