### PR TITLE
fix: no crear tablas de Telescope en producción (dev-only)

### DIFF
--- a/database/migrations/2025_03_30_034051_create_telescope_entries_table.php
+++ b/database/migrations/2025_03_30_034051_create_telescope_entries_table.php
@@ -19,6 +19,14 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Telescope es dev-only (require-dev); en producción se instala con
+        // --no-dev y NO debe grabar. Sin este guard, cada BD de tenant crea
+        // tablas telescope_* inútiles, y en el pasado el histórico infló la BD
+        // hasta 16 GB. Solo se crean cuando el paquete está realmente instalado.
+        if (! class_exists(\Laravel\Telescope\TelescopeServiceProvider::class)) {
+            return;
+        }
+
         $schema = Schema::connection($this->getConnection());
 
         $schema->create('telescope_entries', function (Blueprint $table) {


### PR DESCRIPTION
## Contexto
En producción la BD había crecido a **16.8 GB**, de los cuales **~16.7 GB eran Telescope** (`telescope_entries` 13.6 GB / 13.3M filas + `telescope_entries_tags` 3.1 GB). La data real del negocio es **~16 MB**. Eso hacía que el backup pesara 918 MB y el botón manual diera 504. Ya se purgaron esas tablas en prod (`DROP`), la BD quedó en **16 MB**.

## Causa
`laravel/telescope` está en `require-dev` (no se instala en prod con `--no-dev`, así que no graba). Pero su **migración está publicada** en `database/migrations/`, de modo que se ejecuta en cada BD de tenant creando tablas `telescope_*` aunque el paquete no exista. El histórico de 16 GB venía de cuando prod corría en Nixpacks con dependencias de dev.

## Cambio
Guard en `2025_03_30_...create_telescope_entries_table.php`: la migración solo crea las tablas si `Laravel\Telescope\TelescopeServiceProvider` existe (es decir, si el paquete está instalado). En dev sigue funcionando igual; en prod ya no crea nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
