### PR TITLE
fix: monitorear el mismo disco de backup (BACKUP_DISK)

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -257,7 +257,10 @@ return [
     'monitor_backups' => [
         [
             'name' => env('BACKUP_ARCHIVE_NAME', 'DipleBill'),
-            'disks' => ['local'],
+            // Vigilar el MISMO disco al que se respalda (BACKUP_DISK). Estaba fijo
+            // en 'local', así que en producción (BACKUP_DISK=s3) el monitor de
+            // salud revisaba un disco vacío y reportaba backups inexistentes.
+            'disks' => [env('BACKUP_DISK', 'local')],
             'health_checks' => [
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,


### PR DESCRIPTION
## Qué arregla
El backup a **Backblaze B2 (s3) ya funciona** ("Successfully copied zip to disk named s3"), pero `backup:list` / `backup:monitor` seguían mostrando solo el disco `local`.

Causa: en `config/backup.php`, `monitor_backups[0].disks` estaba fijo en `['local']`, mientras que el destino (`backup.destination.disks`) usa `env('BACKUP_DISK')`. Con `BACKUP_DISK=s3`, el chequeo diario de salud revisaba el disco `local` (efímero, ya sin uso) y podría reportar "no hay backups" / unhealthy.

## Cambio
`monitor_backups[0].disks` → `[env('BACKUP_DISK', 'local')]`, para vigilar el mismo disco al que se respalda.

## Después de mergear
Redeploy → `php artisan backup:list` mostrará el disco `s3` Reachable ✅, y el monitor diario (scheduler → `backup:monitor`) vigilará B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
