### PR TITLE
Paquete 2: bugs de licencia y pagos (backend)

### DIFF
--- a/app/Http/Controllers/Admin/AdminPaymentController.php
+++ b/app/Http/Controllers/Admin/AdminPaymentController.php
@@ -125,38 +125,62 @@ class AdminPaymentController extends Controller
                 ->withErrors(['error' => 'Este comprobante no tiene un plan asociado. Selecciona el plan a aplicar antes de aprobar (sin plan no se puede extender la licencia).']);
         }
 
-        // Extender la licencia por la duración del plan (misma lógica del panel).
-        $baseDate = ($organization->license_expires_at && $organization->license_expires_at->isFuture())
-            ? $organization->license_expires_at
-            : now();
-        $newExpiresAt = $baseDate->copy()->addMonths($plan->duration_months);
-        $periodStart = $baseDate;
-        $periodEnd = $newExpiresAt;
+        // Sección crítica bajo lock: re-verificar que el comprobante sigue
+        // 'pending' y extender la licencia UNA sola vez. Sin este lock, dos
+        // aprobaciones concurrentes (o un doble clic) extenderían 2x la licencia.
+        $periodStart = null;
+        $periodEnd = null;
+        $race = false;
 
-        $organization->licenses()->create([
-            'type' => 'add',
-            'days' => $plan->duration_months * 30,
-            'previous_expires_at' => $organization->license_expires_at,
-            'new_expires_at' => $newExpiresAt,
-        ]);
-        $organization->update([
-            'plan_id' => $plan->id,
-            'tenancy_type' => $plan->tenancy_type,
-            'is_lifetime' => false,
-            'license_expires_at' => $newExpiresAt,
-        ]);
+        \Illuminate\Support\Facades\DB::connection('central')->transaction(function () use ($id, $plan, $request, &$submission, &$organization, &$periodStart, &$periodEnd, &$race) {
+            $locked = PaymentSubmission::where('id', $id)->lockForUpdate()->first();
+            if (!$locked || $locked->status !== 'pending') {
+                $race = true;
+                return;
+            }
 
-        // Si el comprobante no traía plan, persistirlo ahora para la factura y la trazabilidad.
-        if (!$submission->plan_id) {
-            $submission->plan_id = $plan->id;
+            // Releer la organización bloqueada para calcular la nueva expiración
+            // sobre el valor vigente (no uno stale).
+            $organization = Organization::where('id', $organization->id)->lockForUpdate()->first();
+
+            $baseDate = ($organization->license_expires_at && $organization->license_expires_at->isFuture())
+                ? $organization->license_expires_at
+                : now();
+            $newExpiresAt = $baseDate->copy()->addMonths($plan->duration_months);
+            $periodStart = $baseDate;
+            $periodEnd = $newExpiresAt;
+
+            $organization->licenses()->create([
+                'type' => 'add',
+                // Días reales agregados (addMonths no siempre son 30): registrar el
+                // diff exacto en vez de meses*30, que descuadraba el historial.
+                'days' => (int) $baseDate->diffInDays($newExpiresAt),
+                'previous_expires_at' => $organization->license_expires_at,
+                'new_expires_at' => $newExpiresAt,
+            ]);
+            $organization->update([
+                'plan_id' => $plan->id,
+                'tenancy_type' => $plan->tenancy_type,
+                'is_lifetime' => false,
+                'license_expires_at' => $newExpiresAt,
+            ]);
+
+            $locked->update([
+                'status' => 'approved',
+                'admin_notes' => $request->admin_notes,
+                'reviewed_by' => \Illuminate\Support\Facades\Auth::guard('admin')->id(),
+                'reviewed_at' => now(),
+                // Persistir el plan resuelto si el comprobante no lo traía.
+                'plan_id' => $locked->plan_id ?: $plan->id,
+            ]);
+
+            $submission = $locked;
+        });
+
+        if ($race) {
+            return redirect()->route('admin.payments.index')
+                ->withErrors(['error' => 'Este comprobante ya fue revisado.']);
         }
-
-        $submission->update([
-            'status' => 'approved',
-            'admin_notes' => $request->admin_notes,
-            'reviewed_by' => \Illuminate\Support\Facades\Auth::guard('admin')->id(),
-            'reviewed_at' => now(),
-        ]);
 
         // Emitir la factura de DipleBill hacia el cliente (PDF descargable). No debe
         // romper la aprobación si algo falla.

--- a/app/Http/Controllers/Admin/AdminPaymentController.php
+++ b/app/Http/Controllers/Admin/AdminPaymentController.php
@@ -28,7 +28,10 @@ class AdminPaymentController extends Controller
             ->limit(20)
             ->get();
 
-        return view('admin.payments.index', compact('providers', 'pending', 'recent'));
+        // Para asignar plan al aprobar comprobantes que no lo traen.
+        $plans = Plan::where('is_active', true)->orderBy('price')->get();
+
+        return view('admin.payments.index', compact('providers', 'pending', 'recent', 'plans'));
     }
 
     // ---- CRUD de métodos de pago ----
@@ -110,31 +113,42 @@ class AdminPaymentController extends Controller
                 ->withErrors(['error' => 'La organización ya no existe.']);
         }
 
-        // Si el comprobante trae un plan, se asigna y se extiende la licencia por
-        // su duración. Reutiliza la misma lógica de asignación del panel.
-        $plan = $submission->plan_id ? Plan::find($submission->plan_id) : null;
-        $periodStart = null;
-        $periodEnd = null;
-        if ($plan) {
-            $baseDate = ($organization->license_expires_at && $organization->license_expires_at->isFuture())
-                ? $organization->license_expires_at
-                : now();
-            $newExpiresAt = $baseDate->copy()->addMonths($plan->duration_months);
-            $periodStart = $baseDate;
-            $periodEnd = $newExpiresAt;
+        // Resolver el plan a aplicar: el del comprobante, o el que el admin
+        // seleccione en el formulario si el comprobante no traía uno. SIN plan no
+        // se puede extender la licencia, así que no se permite aprobar: antes se
+        // marcaba "aprobado/renovado" sin extender ni un día (mensaje engañoso).
+        $planId = $submission->plan_id ?: $request->input('plan_id');
+        $plan = $planId ? Plan::find($planId) : null;
 
-            $organization->licenses()->create([
-                'type' => 'add',
-                'days' => $plan->duration_months * 30,
-                'previous_expires_at' => $organization->license_expires_at,
-                'new_expires_at' => $newExpiresAt,
-            ]);
-            $organization->update([
-                'plan_id' => $plan->id,
-                'tenancy_type' => $plan->tenancy_type,
-                'is_lifetime' => false,
-                'license_expires_at' => $newExpiresAt,
-            ]);
+        if (!$plan) {
+            return redirect()->route('admin.payments.index')
+                ->withErrors(['error' => 'Este comprobante no tiene un plan asociado. Selecciona el plan a aplicar antes de aprobar (sin plan no se puede extender la licencia).']);
+        }
+
+        // Extender la licencia por la duración del plan (misma lógica del panel).
+        $baseDate = ($organization->license_expires_at && $organization->license_expires_at->isFuture())
+            ? $organization->license_expires_at
+            : now();
+        $newExpiresAt = $baseDate->copy()->addMonths($plan->duration_months);
+        $periodStart = $baseDate;
+        $periodEnd = $newExpiresAt;
+
+        $organization->licenses()->create([
+            'type' => 'add',
+            'days' => $plan->duration_months * 30,
+            'previous_expires_at' => $organization->license_expires_at,
+            'new_expires_at' => $newExpiresAt,
+        ]);
+        $organization->update([
+            'plan_id' => $plan->id,
+            'tenancy_type' => $plan->tenancy_type,
+            'is_lifetime' => false,
+            'license_expires_at' => $newExpiresAt,
+        ]);
+
+        // Si el comprobante no traía plan, persistirlo ahora para la factura y la trazabilidad.
+        if (!$submission->plan_id) {
+            $submission->plan_id = $plan->id;
         }
 
         $submission->update([
@@ -165,7 +179,7 @@ class AdminPaymentController extends Controller
             "Comprobante aprobado de {$organization->name}" . ($submission->plan_id ? " (plan renovado)" : ''));
 
         // Notificar al cliente (con la factura PDF adjunta) y avisar internamente.
-        $planName = $submission->plan?->name;
+        $planName = $plan->name;
         $expiresLabel = $organization->license_expires_at?->format('d/m/Y');
         $clientEmail = $organization->user?->email ?? $organization->email;
         $bodyHtml = '<h2>¡Renovación confirmada!</h2>'

--- a/app/Http/Controllers/Api/V1/InvoiceController.php
+++ b/app/Http/Controllers/Api/V1/InvoiceController.php
@@ -152,16 +152,17 @@ class InvoiceController extends Controller
             }
         }
 
-        // Límite de facturación mensual del plan. Las ventas offline que se
-        // sincronizan no se bloquean (el ticket físico ya se emitió).
-        if (!filter_var($request->is_offline, FILTER_VALIDATE_BOOLEAN)) {
-            $organization = \App\Models\Organization::find(Auth::user()->organization_id);
-            if ($organization && !\App\Services\PlanLimits::for($organization)->canCreateInvoice()) {
-                return response()->json([
-                    'message' => 'Has alcanzado el límite de facturas mensuales de tu plan. Actualiza tu plan para seguir facturando.',
-                    'error_code' => 'PLAN_LIMIT_INVOICES',
-                ], Response::HTTP_FORBIDDEN);
-            }
+        // Límite de facturación mensual del plan. Aplica TAMBIÉN a las facturas
+        // offline: son ventas reales y cuentan para el cupo. Antes el chequeo se
+        // saltaba con is_offline=true — un flag controlado por el cliente —, así
+        // que cualquiera podía facturar ilimitado gratis marcando todo como
+        // offline. Si un negocio necesita más, actualiza su plan.
+        $organization = \App\Models\Organization::find(Auth::user()->organization_id);
+        if ($organization && !\App\Services\PlanLimits::for($organization)->canCreateInvoice()) {
+            return response()->json([
+                'message' => 'Has alcanzado el límite de facturas mensuales de tu plan. Actualiza tu plan para seguir facturando.',
+                'error_code' => 'PLAN_LIMIT_INVOICES',
+            ], Response::HTTP_FORBIDDEN);
         }
 
         $lockKey = 'create_invoice_' . Auth::id() . '_' . md5(json_encode($request->all()));

--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -92,7 +92,9 @@ class OrganizationController extends Controller
                 }
 
                 // 1b. Otorgar licencia de prueba (las licencias se manejan por días)
-                $trialExpiresAt = now()->addDays(self::TRIAL_DAYS);
+                // Hasta el FIN del día de corte (no la hora exacta de registro),
+                // para no cortar el trial a mitad de una jornada de trabajo.
+                $trialExpiresAt = now()->addDays(self::TRIAL_DAYS)->endOfDay();
                 $organization->licenses()->create([
                     'type' => 'add',
                     'days' => self::TRIAL_DAYS,

--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -71,8 +71,20 @@ class OrganizationController extends Controller
                     return ['conflict' => true];
                 }
 
-                // 1. Crear la organización
-                $organization = Organization::create($request->all());
+                // 1. Crear la organización. SOLO campos de perfil: la licencia
+                // (trial) se otorga aparte más abajo. Nunca aceptar
+                // license_expires_at / is_lifetime / plan_id / tenancy_type / status
+                // desde el request del cliente — si no, un dueño podría
+                // auto-otorgarse licencia o marcarse is_lifetime (bypass de cobro).
+                $organization = Organization::create([
+                    'name'        => $request->name,
+                    'email'       => $request->email,
+                    'phone'       => $request->phone,
+                    'website'     => $request->website,
+                    'description' => $request->description,
+                    'owner_id'    => $owner_id,
+                    'status'      => 'active',
+                ]);
 
                 if ($logoPath) {
                     $organization->logo = $logoPath;
@@ -240,7 +252,10 @@ class OrganizationController extends Controller
             $organization->logo = $request->file('logo')->store('organizationLogo', 'public');
         }
 
-        $organization->update($request->all());
+        // Solo campos de perfil editables por el dueño. Nunca license_expires_at,
+        // is_lifetime, plan_id, tenancy_type ni status desde el request del cliente
+        // (esos los controla el panel/aprobación de pagos; si no, bypass de cobro).
+        $organization->update($request->only(['name', 'email', 'phone', 'website', 'description']));
 
         return response(new OrganizationResource($organization), Response::HTTP_ACCEPTED);
     }

--- a/app/Http/Controllers/Api/V1/PaymentController.php
+++ b/app/Http/Controllers/Api/V1/PaymentController.php
@@ -36,7 +36,7 @@ class PaymentController extends Controller
         $request->validate([
             'plan_id' => 'nullable|uuid|exists:central.plans,id',
             'provider_id' => 'nullable|uuid|exists:central.payment_providers,id',
-            'amount' => 'required|numeric|min:0',
+            'amount' => 'required|numeric|min:1',
             'reference' => 'nullable|string|max:255',
             'receipt' => 'required|file|mimes:jpeg,png,jpg,pdf|max:5120',
         ]);

--- a/app/Http/Controllers/Api/V1/PaymentController.php
+++ b/app/Http/Controllers/Api/V1/PaymentController.php
@@ -46,6 +46,14 @@ class PaymentController extends Controller
             return response()->json(['message' => 'No tienes una organización asociada.'], Response::HTTP_FORBIDDEN);
         }
 
+        // Una sola submission pendiente por organización: evita el spam de archivos
+        // de 5MB y de correos a root, y la confusión de comprobantes duplicados.
+        if (PaymentSubmission::where('organization_id', $orgId)->where('status', 'pending')->exists()) {
+            return response()->json([
+                'message' => 'Ya tienes un comprobante pendiente de validación. Espera a que lo revisemos antes de enviar otro.',
+            ], Response::HTTP_CONFLICT);
+        }
+
         // Comprobantes en disco privado (no accesibles públicamente).
         $path = $request->file('receipt')->store("payment_receipts/{$orgId}", 'local');
 

--- a/app/Http/Middleware/TenantDatabaseSwitcher.php
+++ b/app/Http/Middleware/TenantDatabaseSwitcher.php
@@ -18,6 +18,11 @@ class TenantDatabaseSwitcher
      * dominio); ver Illuminate\Http\Request::is().
      */
     private const LICENSE_EXEMPT_ROUTES = [
+        // validateToken debe pasar aunque la licencia esté vencida: si no, el
+        // guard del frontend toma la sesión como inválida y expulsa al usuario a
+        // /login, sin poder llegar a la pantalla de renovación. Devolver el perfil
+        // no da acceso a features (cada una sigue bloqueada con su propio 402).
+        'api/v1/validateToken',
         'api/v1/plans',
         'api/v1/plans/*',
         'api/v1/payments/*',

--- a/app/Http/Middleware/TenantDatabaseSwitcher.php
+++ b/app/Http/Middleware/TenantDatabaseSwitcher.php
@@ -13,6 +13,19 @@ use App\Models\GlobalSetting;
 class TenantDatabaseSwitcher
 {
     /**
+     * Rutas de renovación que siguen accesibles con la licencia vencida, para
+     * que el cliente pueda pagar y salir del bloqueo. Patrones de path (sin
+     * dominio); ver Illuminate\Http\Request::is().
+     */
+    private const LICENSE_EXEMPT_ROUTES = [
+        'api/v1/plans',
+        'api/v1/plans/*',
+        'api/v1/payments/*',
+        'api/v1/subscription-invoices',
+        'api/v1/subscription-invoices/*',
+    ];
+
+    /**
      * Handle an incoming request.
      */
     public function handle(Request $request, Closure $next): Response
@@ -32,12 +45,18 @@ class TenantDatabaseSwitcher
 
                 if (!$organization->is_lifetime) {
                     if (!$organization->license_expires_at || $organization->license_expires_at < now()) {
-                        $supportMessage = GlobalSetting::where('key', 'license_support_message')->value('value') ?? 'Tu licencia ha expirado. Contacta a soporte.';
-                        return response()->json([
-                            'message' => 'Tu licencia de uso ha expirado.',
-                            'error_code' => 'LICENSE_EXPIRED',
-                            'support_message' => $supportMessage,
-                        ], Response::HTTP_PAYMENT_REQUIRED);
+                        // Un cliente con licencia vencida DEBE poder renovar: ver
+                        // los métodos de pago, subir su comprobante y descargar su
+                        // factura. Si bloqueáramos estas rutas aquí quedaría
+                        // atrapado sin forma de pagar. El resto sí se bloquea.
+                        if (!$request->is(...self::LICENSE_EXEMPT_ROUTES)) {
+                            $supportMessage = GlobalSetting::where('key', 'license_support_message')->value('value') ?? 'Tu licencia ha expirado. Contacta a soporte.';
+                            return response()->json([
+                                'message' => 'Tu licencia de uso ha expirado.',
+                                'error_code' => 'LICENSE_EXPIRED',
+                                'support_message' => $supportMessage,
+                            ], Response::HTTP_PAYMENT_REQUIRED);
+                        }
                     }
                 }
 

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -44,8 +44,17 @@
                 <a href="{{ route('admin.payments.receipt', $s->id) }}" target="_blank" style="background: rgba(99,102,241,0.1); color:#818CF8; border:1px solid rgba(99,102,241,0.4); padding:8px 14px; border-radius:8px; font-weight:600; font-size:13px; text-decoration:none;">Ver comprobante</a>
             </div>
             <div style="display:flex; gap:10px; margin-top:14px; flex-wrap:wrap;">
-                <form action="{{ route('admin.payments.approve', $s->id) }}" method="POST" onsubmit="return confirm('¿Aprobar y renovar la licencia de {{ $s->organization?->name }}?')">
+                <form action="{{ route('admin.payments.approve', $s->id) }}" method="POST" onsubmit="return confirm('¿Aprobar y renovar la licencia de {{ $s->organization?->name }}?')" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
                     @csrf
+                    @unless($s->plan_id)
+                        {{-- El comprobante no trae plan: el admin DEBE elegir uno; sin plan no se extiende la licencia. --}}
+                        <select name="plan_id" required style="padding:9px 12px; border-radius:8px; border:1px solid var(--border-color); background:var(--bg-secondary); color:var(--text-primary); font-weight:600;">
+                            <option value="">— Elegir plan a aplicar —</option>
+                            @foreach($plans as $plan)
+                                <option value="{{ $plan->id }}">{{ $plan->name }} · {{ $plan->duration_months }} mes(es) · {{ number_format($plan->price, 2) }} {{ $plan->currency }}</option>
+                            @endforeach
+                        </select>
+                    @endunless
                     <button type="submit" style="background: var(--success-gradient); color:#fff; border:none; padding:9px 18px; border-radius:8px; font-weight:600; cursor:pointer;">Aprobar y renovar</button>
                 </form>
                 <button onclick="openReject('{{ $s->id }}')" style="background: rgba(239,68,68,0.1); color: var(--danger-color); border:1px solid rgba(239,68,68,0.3); padding:9px 18px; border-radius:8px; font-weight:600; cursor:pointer;">Rechazar</button>

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,7 +26,6 @@ use App\Http\Controllers\Api\V1\MovementController;
 use App\Http\Controllers\Api\V1\WooCommerceIntegrationController;
 use App\Http\Controllers\Api\V1\NotificationController;
 use App\Http\Controllers\Api\V1\DashboardController;
-use App\Http\Controllers\Api\V1\LandingAdminController;
 use App\Http\Controllers\Api\V1\LandingPublicController;
 use App\Http\Controllers\Api\V1\PasswordResetController;
 use App\Http\Controllers\Api\V1\SocialAuthController;
@@ -152,7 +151,9 @@ Route::prefix('v1')->group(function () {
 
         // Pagos: métodos activos + comprobantes de renovación
         Route::get('payments/providers', [\App\Http\Controllers\Api\V1\PaymentController::class, 'providers']);
-        Route::post('payments/submit', [\App\Http\Controllers\Api\V1\PaymentController::class, 'submit']);
+        // Throttle contra spam de archivos de 5MB y de correos a root (6/min).
+        Route::post('payments/submit', [\App\Http\Controllers\Api\V1\PaymentController::class, 'submit'])
+            ->middleware('throttle:6,1');
         Route::get('payments/my-submissions', [\App\Http\Controllers\Api\V1\PaymentController::class, 'mySubmissions']);
         Route::get('payments/{id}/receipt', [\App\Http\Controllers\Api\V1\PaymentController::class, 'downloadReceipt']);
 
@@ -206,14 +207,11 @@ Route::prefix('v1')->group(function () {
         Route::post('woocommerce/integration', [WooCommerceIntegrationController::class, 'store']);
         Route::post('woocommerce/integration/test', [WooCommerceIntegrationController::class, 'testConnection']);
 
-        // Landing Page Admin Routes
-        Route::post('/landing/admin/media', [LandingAdminController::class, 'uploadMedia']);
-        Route::get('/landing/admin/media', [LandingAdminController::class, 'getMedia']);
-        Route::delete('/landing/admin/media/{id}', [LandingAdminController::class, 'deleteMedia']);
-        Route::put('/landing/admin/content/{key}', [LandingAdminController::class, 'saveSectionContent']);
-        Route::post('/landing/admin/plans', [LandingAdminController::class, 'managePlan']);
-        Route::put('/landing/admin/plans/{id}', [LandingAdminController::class, 'managePlan']);
-        Route::delete('/landing/admin/plans/{id}', [LandingAdminController::class, 'deletePlan']);
+        // Landing Page Admin: ELIMINADAS. Estas rutas quedaban bajo auth:sanctum
+        // (cualquier dueño de tenant autenticado) y sin ninguna autorización, así
+        // que un cliente cualquiera podía editar la landing GLOBAL. La edición de
+        // la landing vive en el panel root (guard 'admin', AdminLandingController,
+        // ver routes/web.php). Ningún frontend consumía estos endpoints.
 
         // Notifications Module
         Route::get('notifications', [NotificationController::class, 'index']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,8 @@ Route::get('/', function () {
 Route::prefix('admin')->group(function () {
     // Public login/logout routes
     Route::get('/login', [AdminAuthController::class, 'showLoginForm'])->name('admin.login');
-    Route::post('/login', [AdminAuthController::class, 'login']);
+    // Throttle contra fuerza bruta del super-admin (5 intentos/min por IP).
+    Route::post('/login', [AdminAuthController::class, 'login'])->middleware('throttle:5,1');
     Route::post('/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
 
     // Protected dashboard & client actions routes


### PR DESCRIPTION
## Paquete 2 — Bugs de licencia y pagos (backend)

Cierra los hallazgos de licencia/pagos de la auditoría de lanzamiento. 3 commits (críticos / altos / medios+bajos).

### 🔴 Críticos
1. **Mass assignment de licencia (bypass de cobro).** `OrganizationController::store/update` usaban `create/update($request->all())`; como `license_expires_at`, `is_lifetime`, `plan_id`, `tenancy_type` y `status` están en `$fillable`, un dueño podía enviarlos en el registro/edición y **auto-otorgarse licencia o marcarse lifetime**. Ahora solo se aceptan campos de perfil.
2. **Licencia vencida atrapaba al cliente.** `TenantDatabaseSwitcher` devolvía `402 LICENSE_EXPIRED` para todo el grupo, incluidas `payments/*`, `plans`, `subscription-invoices`, así que el cliente no podía ni ver métodos de pago ni subir su comprobante. Se exime esa whitelist del bloqueo (sigue haciendo el tenant switch).
3. **Aprobar renovación sin plan.** `approveSubmission` marcaba "aprobado/renovado" y enviaba "tu licencia quedó activa" aunque, sin `plan_id`, no extendía ni un día. Ahora exige plan (del comprobante o de un selector nuevo en el panel); sin plan no se aprueba.

### 🟠 Altos
4. **Login `/admin` sin throttle** → `throttle:5,1`.
5. **`payments/submit` sin límite** (spam de archivos 5MB + correos a root) → `throttle:6,1` + rechazo 409 si ya hay un comprobante pendiente.
6. **Rutas `/landing/admin/*` del API tenant sin autorización**: cualquier dueño de tenant podía editar la landing GLOBAL. No las usaba ningún frontend (la landing se edita en el panel root, guard `admin`). **Eliminadas.**

### 🟡 Medios
7. **Aprobación doble concurrente** extendía la licencia 2×. `approveSubmission` ahora corre bajo transacción + `lockForUpdate` (comprobante y organización) con re-chequeo de status.
8. **Monto del comprobante** permitía `min:0` → `min:1`.
9. **Límite mensual de facturas** se saltaba con `is_offline=true` (flag del cliente). Ahora las facturas offline también cuentan para el cupo del plan.

### ⚪ Bajos
- Historial de licencias: `days` = diff real (antes `meses*30` con `addMonths`).
- Trial expira al **fin del día** de corte (`endOfDay`), no a la hora exacta de registro.
- **No cambiado (a propósito):** PIN por defecto `1234` del seller del dueño — randomizarlo lo dejaría fuera del POS; necesita un flujo de "cambiar PIN al primer ingreso" (frontend).

### Verificación
`php -l` en todos los archivos; suite relevante (PlanLimits, MultiTenancy, TenantIsolation, InvoiceProforma, Notifications) en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
