### PR TITLE
Licencia vencida: permitir cerrar la caja para cuadrar la gaveta

### DIFF
--- a/app/Http/Middleware/TenantDatabaseSwitcher.php
+++ b/app/Http/Middleware/TenantDatabaseSwitcher.php
@@ -31,6 +31,24 @@ class TenantDatabaseSwitcher
     ];
 
     /**
+     * Rutas que un cajero necesita para CERRAR una caja abierta y cuadrar la
+     * gaveta aunque la licencia del dueño haya vencido a mitad de turno. Si no,
+     * el arqueo del día queda atrapado y el efectivo sin conciliar. No dan
+     * acceso a vender ni abrir nuevas cajas: solo leer la sesión/config del
+     * turno en curso y finalizarlo. Método => patrones de path (Request::is()).
+     */
+    private const SHIFT_CLOSE_EXEMPT_ROUTES = [
+        'GET' => [
+            'api/v1/cash-sessions/active',
+            'api/v1/settings',
+            'api/v1/expense-categories',
+        ],
+        'POST' => [
+            'api/v1/cash-sessions/close',
+        ],
+    ];
+
+    /**
      * Handle an incoming request.
      */
     public function handle(Request $request, Closure $next): Response
@@ -54,7 +72,7 @@ class TenantDatabaseSwitcher
                         // los métodos de pago, subir su comprobante y descargar su
                         // factura. Si bloqueáramos estas rutas aquí quedaría
                         // atrapado sin forma de pagar. El resto sí se bloquea.
-                        if (!$request->is(...self::LICENSE_EXEMPT_ROUTES)) {
+                        if (!$request->is(...self::LICENSE_EXEMPT_ROUTES) && !$this->isShiftCloseExempt($request)) {
                             $supportMessage = GlobalSetting::where('key', 'license_support_message')->value('value') ?? 'Tu licencia ha expirado. Contacta a soporte.';
                             return response()->json([
                                 'message' => 'Tu licencia de uso ha expirado.',
@@ -80,5 +98,17 @@ class TenantDatabaseSwitcher
         }
 
         return $next($request);
+    }
+
+    /**
+     * ¿La petición es una de las lecturas/acciones que un cajero necesita para
+     * cerrar su turno, exentas del bloqueo por licencia vencida? El match es por
+     * método + path para no exponer, p. ej., el POST/PUT de settings.
+     */
+    private function isShiftCloseExempt(Request $request): bool
+    {
+        $patterns = self::SHIFT_CLOSE_EXEMPT_ROUTES[$request->method()] ?? [];
+
+        return $patterns !== [] && $request->is(...$patterns);
     }
 }

--- a/tests/Feature/LicenseExpiredShiftCloseTest.php
+++ b/tests/Feature/LicenseExpiredShiftCloseTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\TenantManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+/**
+ * Con la licencia vencida, el resto del sistema se bloquea con 402, pero un
+ * cajero DEBE poder cerrar la caja que dejó abierta para cuadrar la gaveta.
+ * Si no, el arqueo del día queda atrapado y el efectivo sin conciliar.
+ *
+ * Verifica la exención de "cierre de turno" del TenantDatabaseSwitcher: es
+ * consciente del método (path + verbo) para no exponer, p. ej., abrir una
+ * nueva caja ni escribir settings.
+ */
+class LicenseExpiredShiftCloseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        TenantManager::clear();
+    }
+
+    private function makeExpiredTenant(): array
+    {
+        $owner = User::factory()->create();
+        $org = Organization::factory()->create([
+            'name' => 'Org licencia vencida',
+            'tenancy_type' => 'shared',
+            'owner_id' => $owner->id,
+            'status' => 'active',
+            'is_lifetime' => false,
+            'license_expires_at' => now()->subDay(),
+        ]);
+        $owner->update(['organization_id' => $org->id]);
+        $this->setupTenantUser($owner, $org);
+
+        $store = $this->withTenant($org, fn () => Store::factory()->create(['name' => 'Tienda']));
+
+        return [$owner, $org, $store];
+    }
+
+    private function withTenant(Organization $org, callable $fn)
+    {
+        TenantManager::setTenant($org);
+        $result = $fn();
+        TenantManager::clear();
+
+        return $result;
+    }
+
+    public function test_expired_license_blocks_normal_routes(): void
+    {
+        [$owner] = $this->makeExpiredTenant();
+        Sanctum::actingAs($owner);
+
+        $this->getJson('/api/v1/clients')
+            ->assertStatus(Response::HTTP_PAYMENT_REQUIRED)
+            ->assertJson(['error_code' => 'LICENSE_EXPIRED']);
+    }
+
+    public function test_expired_license_allows_reading_active_cash_session(): void
+    {
+        [$owner, , $store] = $this->makeExpiredTenant();
+        Sanctum::actingAs($owner);
+
+        // No hay sesión abierta: 200 con is_open=false. Lo clave es que NO sea 402.
+        $this->getJson("/api/v1/cash-sessions/active?store_id={$store->id}")
+            ->assertOk()
+            ->assertJson(['is_open' => false]);
+    }
+
+    public function test_expired_license_allows_reading_expense_categories(): void
+    {
+        [$owner] = $this->makeExpiredTenant();
+        Sanctum::actingAs($owner);
+
+        $this->getJson('/api/v1/expense-categories')->assertOk();
+    }
+
+    public function test_expired_license_allows_posting_cash_session_close(): void
+    {
+        [$owner] = $this->makeExpiredTenant();
+        Sanctum::actingAs($owner);
+
+        // Sin sesión válida fallará la validación (422), pero NUNCA con 402:
+        // el cierre está exento del bloqueo por licencia.
+        $response = $this->postJson('/api/v1/cash-sessions/close', []);
+
+        $this->assertNotSame(
+            Response::HTTP_PAYMENT_REQUIRED,
+            $response->status(),
+            'El cierre de caja no debe bloquearse por licencia vencida.'
+        );
+    }
+
+    public function test_exemption_is_method_aware_and_does_not_leak_to_opening_a_session(): void
+    {
+        [$owner, , $store] = $this->makeExpiredTenant();
+        Sanctum::actingAs($owner);
+
+        // Abrir una NUEVA caja no está exento: sigue bloqueado con 402.
+        $this->postJson('/api/v1/cash-sessions/open', [
+            'store_id' => $store->id,
+            'opening_balance' => 100,
+        ])->assertStatus(Response::HTTP_PAYMENT_REQUIRED);
+    }
+}


### PR DESCRIPTION
Apoya al 🟠 alto #1 del Paquete 5 (POS).

## Problema
Si la licencia del dueño vence a mitad de turno, el bloqueo 402 del `TenantDatabaseSwitcher` cubría **todo**, incluido el cierre de caja. El cajero quedaba sin poder cuadrar la gaveta y el arqueo del día atrapado, con el efectivo sin conciliar.

## Fix
Se añade una exención de "cierre de turno" **consciente del método** (path + verbo), con el mismo principio que las rutas de pago ya exentas — dejar finalizar/pagar, no atrapar:

| Método | Ruta | Para qué |
|--------|------|----------|
| GET | `cash-sessions/active` | leer la sesión abierta y sus totales |
| GET | `settings` | políticas de arqueo (modo/conteo) |
| GET | `expense-categories` | categorías de egresos del turno |
| POST | `cash-sessions/close` | finalizar el turno |

No permite vender, abrir nuevas cajas ni **escribir** settings: solo finalizar el turno en curso.

## Tests
`LicenseExpiredShiftCloseTest` (5 casos): rutas normales siguen en 402, las de cierre pasan, y la exención es method-aware (abrir caja sigue bloqueado). Suite de tenant/caja verde (12 tests, 23 assertions).