### PR TITLE
Verificación de correo en el registro + TrustProxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,13 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
+# En producción DEBE ser el dominio público https (los enlaces de verificación
+# de correo se firman con esta URL): APP_URL=https://api.diplebill.com
 APP_URL=http://localhost
+
+# URL de la app del cliente (SPA del dueño). Destino del botón tras verificar el
+# correo. Producción: FRONTEND_URL=https://app.diplebill.com
+FRONTEND_URL=http://localhost:5173
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/app/Http/Controllers/Api/V1/LoginController.php
+++ b/app/Http/Controllers/Api/V1/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Services\MailConfigurator;
 use Illuminate\Support\Facades\Hash;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Auth;
@@ -149,8 +150,17 @@ class LoginController extends Controller
             'must_change_password' => false
         ]);
 
-        //dd($user);
         if ($user) {
+            // Enviar el correo de verificación. No bloquea el registro si el
+            // correo falla (el usuario igual entra al trial). El SMTP se
+            // configura desde el panel y va sin cola → envío síncrono.
+            try {
+                MailConfigurator::applyConfiguration();
+                $user->sendEmailVerificationNotification();
+            } catch (\Throwable $e) {
+                report($e);
+            }
+
             return response()->json([
                 'data' => [
                     'attributes' => [
@@ -162,6 +172,30 @@ class LoginController extends Controller
                 ]
             ], Response::HTTP_CREATED); //201
         }
+    }
+
+    /**
+     * Reenvía el correo de verificación al usuario autenticado.
+     */
+    public function resendVerificationEmail(Request $request)
+    {
+        $user = $request->user();
+
+        if ($user->hasVerifiedEmail()) {
+            return response()->json(['message' => 'Tu correo ya está verificado.'], Response::HTTP_OK);
+        }
+
+        try {
+            MailConfigurator::applyConfiguration();
+            $user->sendEmailVerificationNotification();
+        } catch (\Throwable $e) {
+            report($e);
+            return response()->json([
+                'message' => 'No se pudo enviar el correo de verificación. Intenta más tarde.'
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return response()->json(['message' => 'Correo de verificación reenviado.'], Response::HTTP_OK);
     }
 
     public function validationToken(Request $request)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -12,7 +12,7 @@ use Laravel\Sanctum\HasApiTokens;
 use App\Traits\Uuids;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use Uuids;
     use HasRoles;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,17 @@ class AppServiceProvider extends ServiceProvider
             \Illuminate\Support\Facades\URL::forceScheme('https');
         }
 
+        // Correo de verificación en español (reemplaza la plantilla por defecto de Laravel).
+        \Illuminate\Auth\Notifications\VerifyEmail::toMailUsing(function ($notifiable, string $url) {
+            return (new \Illuminate\Notifications\Messages\MailMessage)
+                ->subject('Verifica tu correo · DipleBill')
+                ->greeting('¡Hola' . ($notifiable->name ? ' ' . $notifiable->name : '') . '!')
+                ->line('Gracias por registrarte en DipleBill. Confirma tu correo para asegurar tu cuenta y recibir los avisos de tu licencia y pagos.')
+                ->action('Verificar mi correo', $url)
+                ->line('El enlace vence en 60 minutos. Si no creaste esta cuenta, puedes ignorar este mensaje.')
+                ->salutation('— El equipo de DipleBill');
+        });
+
         // Register Policies
 
         \Illuminate\Support\Facades\Gate::policy(\App\Models\Store::class, \App\Policies\StorePolicy::class);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,12 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        // La app solo se sirve detrás del proxy de Dokploy (Traefik). Confiar en
+        // él para leer X-Forwarded-* → esquema/host reales (links https correctos,
+        // enlaces de verificación firmados válidos) y IP real del cliente (para
+        // que el throttle por IP no agrupe a todos bajo la IP del proxy).
+        $middleware->trustProxies(at: '*');
+
         $middleware->alias([
             'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
             'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,

--- a/config/app.php
+++ b/config/app.php
@@ -54,6 +54,9 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    // URL de la app del cliente (SPA del dueño). Destino tras verificar el correo.
+    'frontend_url' => env('FRONTEND_URL', 'https://app.diplebill.com'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/resources/views/emails/verified.blade.php
+++ b/resources/views/emails/verified.blade.php
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Correo verificado — DipleBill</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+        .card {
+            width: 100%;
+            max-width: 440px;
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 24px;
+            padding: 40px 32px;
+            text-align: center;
+            box-shadow: 0 20px 50px rgba(0,0,0,.35);
+        }
+        .badge {
+            width: 72px; height: 72px;
+            margin: 0 auto 24px;
+            border-radius: 999px;
+            background: rgba(34,197,94,.12);
+            border: 1px solid rgba(34,197,94,.35);
+            display: flex; align-items: center; justify-content: center;
+        }
+        .badge svg { width: 38px; height: 38px; stroke: #22c55e; }
+        h1 { font-size: 22px; font-weight: 800; color: #fff; margin-bottom: 10px; }
+        p { font-size: 14px; line-height: 1.6; color: #94a3b8; margin-bottom: 28px; }
+        .btn {
+            display: inline-block;
+            background: #4f46e5;
+            color: #fff;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 14px;
+            padding: 14px 28px;
+            border-radius: 12px;
+            transition: background .15s;
+        }
+        .btn:hover { background: #6366f1; }
+        .brand { margin-top: 28px; font-size: 12px; color: #64748b; }
+        .brand b { color: #8fb2f9; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="badge">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20 6 9 17l-5-5"/>
+            </svg>
+        </div>
+        @if ($alreadyVerified)
+            <h1>Tu correo ya estaba verificado</h1>
+            <p>No hay nada más que hacer. Ya puedes iniciar sesión en DipleBill con tu cuenta.</p>
+        @else
+            <h1>¡Correo verificado!</h1>
+            <p>Gracias por confirmar tu correo. Tu cuenta de DipleBill quedó asegurada y ahora recibirás los avisos de tu licencia y pagos.</p>
+        @endif
+        <a class="btn" href="{{ $appUrl }}">Ir a DipleBill</a>
+        <div class="brand"><b>Diple</b>Bill · Factura. Gestiona. Crece.</div>
+    </div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,11 @@ Route::prefix('v1')->group(function () {
     Route::post('/reset-password', [PasswordResetController::class, 'resetPassword']);
     Route::post('/auth/google', [SocialAuthController::class, 'handleGoogle']);
 
+    // Reenviar el correo de verificación. Autenticado pero SIN tenant.switch:
+    // un usuario recién registrado aún no tiene organización.
+    Route::post('/email/verification-notification', [LoginController::class, 'resendVerificationEmail'])
+        ->middleware(['auth:sanctum', 'throttle:6,1']);
+
     // Public Landing Page Routes
     Route::get('/landing/content', [LandingPublicController::class, 'getPublicContent']);
     Route::get('/landing/plans', [LandingPublicController::class, 'getPublicPlans']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,10 +6,35 @@ use App\Http\Controllers\Admin\AdminPlanController;
 use App\Http\Controllers\Admin\AdminPaymentController;
 use App\Http\Controllers\Admin\AdminNotificationController;
 use App\Http\Controllers\Admin\AdminErrorReportController;
+use App\Models\User;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Http\Request;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+// Verificación de correo. El enlace firmado llega en el correo de registro; no
+// requiere sesión iniciada (la firma temporal ES la autorización). El middleware
+// 'signed' valida firma y expiración; abajo se compara el hash del correo.
+Route::get('/email/verify/{id}/{hash}', function (Request $request, string $id, string $hash) {
+    $user = User::find($id);
+
+    if (! $user || ! hash_equals(sha1($user->getEmailForVerification()), $hash)) {
+        abort(403, 'El enlace de verificación no es válido o ya expiró.');
+    }
+
+    $alreadyVerified = $user->hasVerifiedEmail();
+    if (! $alreadyVerified) {
+        $user->markEmailAsVerified();
+        event(new Verified($user));
+    }
+
+    return view('emails.verified', [
+        'appUrl' => config('app.frontend_url'),
+        'alreadyVerified' => $alreadyVerified,
+    ]);
+})->middleware('signed')->name('verification.verify');
 
 Route::prefix('admin')->group(function () {
     // Public login/logout routes

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * El registro debe enviar un correo de verificación y ofrecer un enlace firmado
+ * que marque el correo como verificado. Antes, registerOwner creaba la cuenta y
+ * entregaba el token sin ninguna verificación: cualquier correo con typo o falso
+ * quedaba como cuenta válida, sin recuperación ni avisos de licencia posibles.
+ */
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // central no se revierte con RefreshDatabase (otra conexión): usar correos
+    // únicos por corrida para no colisionar con el unique de users.
+    private function uniqueEmail(): string
+    {
+        return 'verify_' . uniqid() . '@example.test';
+    }
+
+    public function test_registration_sends_verification_email_and_user_starts_unverified(): void
+    {
+        Notification::fake();
+        $email = $this->uniqueEmail();
+
+        $response = $this->postJson('/api/v1/register', [
+            'name' => 'Nuevo Dueño',
+            'email' => $email,
+            'password' => 'secret123',
+            'password_confirm' => 'secret123',
+            'device_name' => 'test-device',
+        ]);
+
+        $response->assertStatus(201);
+
+        $user = User::where('email', $email)->first();
+        $this->assertNotNull($user);
+        $this->assertFalse($user->hasVerifiedEmail());
+
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    public function test_signed_link_marks_email_as_verified(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+        $this->assertFalse($user->hasVerifiedEmail());
+
+        $url = URL::temporarySignedRoute('verification.verify', now()->addMinutes(60), [
+            'id' => $user->id,
+            'hash' => sha1($user->getEmailForVerification()),
+        ]);
+
+        $this->get($url)->assertOk();
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_tampered_hash_is_rejected_and_user_stays_unverified(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $url = URL::temporarySignedRoute('verification.verify', now()->addMinutes(60), [
+            'id' => $user->id,
+            'hash' => sha1('otro-correo@example.test'), // hash que no corresponde
+        ]);
+
+        $this->get($url)->assertForbidden();
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_unsigned_link_is_rejected(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        // Sin firma válida el middleware 'signed' rechaza (403).
+        $this->get("/email/verify/{$user->id}/" . sha1($user->getEmailForVerification()))
+            ->assertForbidden();
+    }
+
+    public function test_resend_requires_authentication(): void
+    {
+        $this->postJson('/api/v1/email/verification-notification')->assertUnauthorized();
+    }
+
+    public function test_authenticated_user_can_resend_verification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create(['email_verified_at' => null]);
+        Sanctum::actingAs($user);
+
+        $this->postJson('/api/v1/email/verification-notification')->assertOk();
+
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+}


### PR DESCRIPTION
Paquete 6, item #2 (+ el pendiente de TrustProxies/APP_URL).

## Problema
`registerOwner` creaba la cuenta y entregaba el token **sin verificar el correo**. Un correo con typo o falso quedaba como cuenta válida: sin recuperación posible, y los avisos de licencia/pago yéndose a un buzón inexistente.

## Cambios
- **`User implements MustVerifyEmail`** (soft-gate): no bloquea el trial, y como ninguna ruta usa el middleware `verified`, los usuarios actuales no se ven afectados.
- **`registerOwner`** envía el correo de verificación (`MailConfigurator` + envío síncrono, en `try/catch` para no romper el registro si el correo falla).
- **`GET /email/verify/{id}/{hash}`** (web, firmado): valida firma + hash, marca verificado y muestra una página de confirmación con botón a la app.
- **`POST /api/v1/email/verification-notification`** (auth + throttle): reenvío.
- Correo de verificación **en español** (`VerifyEmail::toMailUsing`).
- `config('app.frontend_url')` + `FRONTEND_URL`/`APP_URL` documentados en `.env.example`.

## TrustProxies
`trustProxies(at: '*')` — la app solo se sirve tras el proxy de Dokploy. Necesario para que los enlaces firmados se generen/validen con **https + host reales**, y para que el **throttle por IP** no agrupe a todos bajo la IP del proxy.

## Tests
`EmailVerificationTest` (6 casos): envío en registro, verificación por enlace firmado, rechazo de enlace manipulado y sin firma, y reenvío autenticado. Set de regresión (User/auth/notificaciones/tenant/planes): **34 tests, 97 assertions, verde**.

> ⚠️ **Producción:** setear `APP_URL=https://api.diplebill.com` y `FRONTEND_URL=https://app.diplebill.com` en el `.env` del servidor (los enlaces firmados dependen de `APP_URL`).