### PR TITLE
Créditos: anular un abono (pago de crédito)

### DIFF
--- a/app/Http/Controllers/Api/V1/CashSessionController.php
+++ b/app/Http/Controllers/Api/V1/CashSessionController.php
@@ -453,7 +453,10 @@ class CashSessionController extends Controller
         $invoices = Invoice::where('cash_session_id', $session->id)
             ->whereNotIn('invoice_status', ['proforma', 'canceled'])
             ->get();
-        $creditDetails = CreditDetail::where('cash_session_id', $session->id)->get();
+        // Los abonos anulados no cuentan en el arqueo.
+        $creditDetails = CreditDetail::where('cash_session_id', $session->id)
+            ->whereNull('voided_at')
+            ->get();
         
         $invoiceCashNio = 0.0;
         $invoiceCashUsd = 0.0;

--- a/app/Http/Controllers/Api/V1/CreditController.php
+++ b/app/Http/Controllers/Api/V1/CreditController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\CreditCollection;
 use App\Http\Resources\CreditByClientCollection;
 use App\Http\Resources\CreditResource;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\Response;
 class CreditController extends Controller
 {
@@ -250,6 +251,60 @@ class CreditController extends Controller
         }
      
         return response()->json($updatedCredits, 200);
+    }
+
+    /**
+     * Anula un abono (pago de crédito). Anulación suave y auditable: NO borra el
+     * registro, marca voided_at y restaura la deuda del crédito. El abono anulado
+     * deja de contar en el arqueo de caja de sesiones ABIERTAS; las cajas ya
+     * cerradas no se recalculan (su arqueo queda congelado).
+     */
+    public function voidPayment(Request $request, $id)
+    {
+        $this->authorize('payment', Credit::class);
+
+        $orgID = Auth::user()->organization_id;
+
+        $detail = CreditDetail::whereHas('credit', function ($q) use ($orgID) {
+            $q->where('organization_id', $orgID);
+        })->find($id);
+
+        if (!$detail) {
+            return response()->json(['message' => 'Abono no encontrado.'], Response::HTTP_NOT_FOUND);
+        }
+
+        if ($detail->voided_at) {
+            return response()->json(['message' => 'Este abono ya fue anulado.'], Response::HTTP_CONFLICT);
+        }
+
+        DB::transaction(function () use ($detail, $orgID, $request) {
+            $credit = Credit::where('id', $detail->credit_id)
+                ->where('organization_id', $orgID)
+                ->lockForUpdate()
+                ->first();
+
+            if ($credit) {
+                // Restaurar la deuda sin exceder el total del crédito. Si estaba
+                // saldado, vuelve a estar activo porque ahora debe de nuevo.
+                $credit->debt = min((float) $credit->total, (float) $credit->debt + (float) $detail->amount);
+                if ($credit->credit_status === 'paid' && $credit->debt > 0) {
+                    $credit->credit_status = 'active';
+                }
+                $credit->save();
+            }
+
+            $detail->voided_at = now();
+            $detail->voided_by = Auth::id();
+            $detail->void_reason = $request->input('reason');
+            $detail->save();
+        });
+
+        $credit = Credit::where('id', $detail->credit_id)->where('organization_id', $orgID)->first();
+
+        return response()->json([
+            'message' => 'Abono anulado. La deuda del crédito fue restaurada.',
+            'credit' => $credit ? new CreditResource($credit) : null,
+        ], Response::HTTP_OK);
     }
 
 }

--- a/app/Http/Resources/CreditResource.php
+++ b/app/Http/Resources/CreditResource.php
@@ -24,6 +24,8 @@ class CreditResource extends JsonResource
                 'payment_method' => $payment->payment_method ?? 'CASH',
                 'payment_metadata' => $payment->payment_metadata,
                 'cash_session_id' => $payment->cash_session_id,
+                'voided_at' => $payment->voided_at,
+                'void_reason' => $payment->void_reason,
                 'created_at' => $payment->created_at,
                 'updated_at' => $payment->updated_at,
             ];

--- a/app/Models/CreditDetail.php
+++ b/app/Models/CreditDetail.php
@@ -20,10 +20,14 @@ class CreditDetail extends Model
         'payment_method',
         'payment_metadata',
         'cash_session_id',
+        'voided_at',
+        'voided_by',
+        'void_reason',
     ];
 
     protected $casts = [
         'payment_metadata' => 'array',
+        'voided_at' => 'datetime',
     ];
 
     public function credit()

--- a/database/migrations/2026_07_23_010000_add_void_to_credit_details.php
+++ b/database/migrations/2026_07_23_010000_add_void_to_credit_details.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Permite ANULAR un abono (pago de crédito) sin borrarlo: anulación suave y
+ * auditable. Al anular se restaura la deuda del crédito y el abono deja de
+ * contar en el arqueo de caja de sesiones abiertas.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('credit_details', function (Blueprint $table) {
+            $table->timestamp('voided_at')->nullable()->after('note');
+            $table->uuid('voided_by')->nullable()->after('voided_at'); // usuario que anuló
+            $table->string('void_reason')->nullable()->after('voided_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('credit_details', function (Blueprint $table) {
+            $table->dropColumn(['voided_at', 'voided_by', 'void_reason']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -180,6 +180,7 @@ Route::prefix('v1')->group(function () {
         Route::middleware('module:credits')->group(function () {
             Route::get('credits/search-active', [CreditController::class, 'searchActive']);
             Route::post('credits/payment', [CreditController::class, 'payment']);
+            Route::post('credits/payment/{id}/void', [CreditController::class, 'voidPayment']);
             Route::apiResource('credits', CreditController::class)->except(['store', 'update', 'destroy']);
             Route::get('credits-by-client', [CreditController::class, 'indexByClient']);
             Route::get('credits-by-client/{client_id}', [CreditController::class, 'indexByClientID']);

--- a/tests/Feature/VoidCreditPaymentTest.php
+++ b/tests/Feature/VoidCreditPaymentTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Credit;
+use App\Models\CreditDetail;
+use App\Models\Module;
+use App\Models\Organization;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\TenantManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Anular un abono (pago de crédito) debe restaurar la deuda del crédito y dejar
+ * el abono marcado como anulado (auditable), sin borrarlo. Antes no existía la
+ * forma de anular un abono registrado por error.
+ */
+class VoidCreditPaymentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        TenantManager::clear();
+    }
+
+    private function makeOrgOwner(): array
+    {
+        $owner = User::factory()->create();
+        $org = Organization::factory()->create([
+            'tenancy_type' => 'shared',
+            'owner_id' => $owner->id,
+            'status' => 'active',
+        ]);
+        $owner->update(['organization_id' => $org->id]);
+        $this->setupTenantUser($owner, $org);
+
+        // Módulo de créditos activo (para pasar el middleware module:credits).
+        $module = Module::firstOrCreate(['slug' => 'credits'], ['name' => 'Créditos']);
+        $org->modules()->syncWithoutDetaching([$module->id => ['status' => 'active']]);
+
+        return [$owner, $org];
+    }
+
+    private function withTenant(Organization $org, callable $fn)
+    {
+        TenantManager::setTenant($org);
+        $result = $fn();
+        TenantManager::clear();
+
+        return $result;
+    }
+
+    private function makeCreditWithAbono(User $owner, Organization $org, float $total, float $debt, float $abono, string $status): array
+    {
+        return $this->withTenant($org, function () use ($owner, $org, $total, $debt, $abono, $status) {
+            // El crédito cuelga de una factura; la factory arma sus dependencias.
+            $invoice = \App\Models\Invoice::factory()->create();
+            $credit = Credit::create([
+                'user_id' => $owner->id,
+                'organization_id' => $org->id,
+                'store_id' => $invoice->store_id,
+                'client_id' => $invoice->client_id,
+                'invoice_id' => $invoice->id,
+                'total' => $total,
+                'debt' => $debt,
+                'credit_status' => $status,
+            ]);
+            $detail = CreditDetail::create([
+                'credit_id' => $credit->id,
+                'amount' => $abono,
+                'date' => now()->toDateString(),
+                'payment_method' => 'CASH',
+            ]);
+
+            return [$credit, $detail];
+        });
+    }
+
+    public function test_voiding_an_abono_restores_the_debt(): void
+    {
+        [$owner, $org] = $this->makeOrgOwner();
+        // total 100, ya se abonaron 40 → debt 60.
+        [$credit, $detail] = $this->makeCreditWithAbono($owner, $org, 100, 60, 40, 'active');
+
+        Sanctum::actingAs($owner);
+
+        $this->postJson("/api/v1/credits/payment/{$detail->id}/void", ['reason' => 'error de digitación'])
+            ->assertOk();
+
+        $this->assertSame(100.0, (float) $credit->fresh()->debt);
+        $this->assertNotNull($detail->fresh()->voided_at);
+    }
+
+    public function test_voiding_the_abono_of_a_paid_credit_reactivates_it(): void
+    {
+        [$owner, $org] = $this->makeOrgOwner();
+        // Crédito saldado con un abono de 100 → al anular vuelve a deber.
+        [$credit, $detail] = $this->makeCreditWithAbono($owner, $org, 100, 0, 100, 'paid');
+
+        Sanctum::actingAs($owner);
+
+        $this->postJson("/api/v1/credits/payment/{$detail->id}/void")->assertOk();
+
+        $fresh = $credit->fresh();
+        $this->assertSame(100.0, (float) $fresh->debt);
+        $this->assertSame('active', $fresh->credit_status);
+    }
+
+    public function test_cannot_void_the_same_abono_twice(): void
+    {
+        [$owner, $org] = $this->makeOrgOwner();
+        [, $detail] = $this->makeCreditWithAbono($owner, $org, 100, 60, 40, 'active');
+
+        Sanctum::actingAs($owner);
+
+        $this->postJson("/api/v1/credits/payment/{$detail->id}/void")->assertOk();
+        $this->postJson("/api/v1/credits/payment/{$detail->id}/void")->assertStatus(409);
+    }
+}


### PR DESCRIPTION
No existía forma de anular un abono registrado por error. Anulación suave y auditable: migración voided_at/by/reason, POST /v1/credits/payment/{id}/void (restaura la deuda del crédito, reactiva si estaba saldado, 409 en doble anulación), el arqueo excluye los anulados, y CreditResource expone voided_at. Tests: VoidCreditPaymentTest. Pareja: PR de la app del dueño.