### PR TITLE
security: endurecimiento P0/P1/P2 (RCE upload, OAuth, multitenant, SSRF, config)

### DIFF
--- a/app/Exports/InventoryExport.php
+++ b/app/Exports/InventoryExport.php
@@ -19,17 +19,31 @@ class InventoryExport implements FromCollection, WithHeadings, WithColumnFormatt
     {
         return collect($this->products)->map(function ($product) {
             return [
-                $product['product_name'] ?? '',
+                self::csvSafe($product['product_name'] ?? ''),
                 (string)$product['quantity'] ?? '0',
-                $product['status'] ?? '',
+                self::csvSafe($product['status'] ?? ''),
                 $product['price'] ?? '0',
                 $product['cost'] ?? '0',
-                (string) $product['barcode'] ?? '',
-                (string)$product['sku'] ?? '',
-                $product['tags'] ?? '',
-                $product['category'] ?? '',
+                self::csvSafe((string) ($product['barcode'] ?? '')),
+                self::csvSafe((string) ($product['sku'] ?? '')),
+                self::csvSafe($product['tags'] ?? ''),
+                self::csvSafe($product['category'] ?? ''),
             ];
         });
+    }
+
+    /**
+     * SEGURIDAD (CSV/formula injection): un valor que empieza con = + - @ (o tab/CR)
+     * es interpretado como fórmula por Excel/LibreOffice al abrir el archivo. Se le
+     * antepone un apóstrofo para forzar que se trate como texto.
+     */
+    public static function csvSafe($value): string
+    {
+        $value = (string) $value;
+        if ($value !== '' && in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true)) {
+            return "'" . $value;
+        }
+        return $value;
     }
 
     public function headings(): array

--- a/app/Exports/InvoiceExport.php
+++ b/app/Exports/InvoiceExport.php
@@ -4,8 +4,9 @@ namespace App\Exports;
 
 use App\Models\Invoice;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithMapping;
 
-class InvoiceExport implements FromCollection
+class InvoiceExport implements FromCollection, WithMapping
 {
     protected $data;
 
@@ -17,5 +18,17 @@ class InvoiceExport implements FromCollection
     public function collection()
     {
         return $this->data;
+    }
+
+    /**
+     * SEGURIDAD (CSV/formula injection): neutralizar los valores de texto
+     * (client_name, etc.) para que Excel no ejecute fórmulas al abrir el archivo.
+     */
+    public function map($invoice): array
+    {
+        $row = is_array($invoice) ? $invoice : $invoice->toArray();
+        return array_map(function ($v) {
+            return is_string($v) ? InventoryExport::csvSafe($v) : $v;
+        }, $row);
     }
 }

--- a/app/Http/Controllers/Admin/AdminLandingController.php
+++ b/app/Http/Controllers/Admin/AdminLandingController.php
@@ -73,7 +73,7 @@ class AdminLandingController extends Controller
     public function uploadMedia(Request $request)
     {
         $request->validate([
-            'file' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:5120',
+            'file' => 'required|image|mimes:jpeg,png,jpg,gif,webp|max:5120',
         ]);
 
         $file = $request->file('file');

--- a/app/Http/Controllers/Api/V1/CashSessionController.php
+++ b/app/Http/Controllers/Api/V1/CashSessionController.php
@@ -134,6 +134,15 @@ class CashSessionController extends Controller
 
         $session = CashSession::findOrFail($request->cash_session_id);
 
+        // SEGURIDAD: solo el dueño de la sesión (o el owner de la org) puede
+        // inyectar movimientos. Sin esto, cualquier usuario del tenant metía
+        // "gastos" en la caja abierta de otro cajero.
+        if (!$this->userOwnsSessionOrIsOwner($session)) {
+            return response()->json([
+                'message' => 'No autorizado sobre esta sesión de caja.'
+            ], Response::HTTP_FORBIDDEN);
+        }
+
         if ($session->status !== 'open') {
             return response()->json([
                 'message' => 'La sesión de caja está cerrada.'
@@ -176,6 +185,15 @@ class CashSessionController extends Controller
         ]);
 
         $session = CashSession::findOrFail($request->cash_session_id);
+
+        // SEGURIDAD: solo el dueño de la sesión (o el owner de la org) puede
+        // cerrarla. Sin esto, cualquiera cerraba la caja de otro cajero con un
+        // actual_cash falso, generando descuadres/incriminaciones.
+        if (!$this->userOwnsSessionOrIsOwner($session)) {
+            return response()->json([
+                'message' => 'No autorizado sobre esta sesión de caja.'
+            ], Response::HTTP_FORBIDDEN);
+        }
 
         if ($session->status !== 'open') {
             return response()->json([
@@ -413,6 +431,18 @@ class CashSessionController extends Controller
             'expected_usd' => $expected_usd,
             'difference' => $diff,
         ]);
+    }
+
+    /**
+     * ¿El usuario autenticado es dueño de esta sesión de caja, o el owner de la org?
+     */
+    private function userOwnsSessionOrIsOwner(CashSession $session): bool
+    {
+        $user = Auth::user();
+        if ($session->user_id === $user->id) {
+            return true;
+        }
+        return $user->organization && $user->id === $user->organization->owner_id;
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Models\Category;
+use App\Models\Product;
 
 
 use App\Http\Requests\StoreCategoryRequest;
@@ -13,11 +14,16 @@ use App\Http\Resources\CategoryResource;
 
 
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class CategoryController extends Controller
 {
+    // SEGURIDAD: este controlador no autorizaba nada -> un usuario sin permisos
+    // de producto podía borrar/renombrar toda la taxonomía. Reusa product.*.
+    use AuthorizesRequests;
+
     /**
      * Display a listing of the resource.
      */
@@ -35,6 +41,7 @@ class CategoryController extends Controller
      */
     public function store(StoreCategoryRequest $request)
     {
+        $this->authorize('create', Product::class);
         $orgId = Auth::user()->organization_id;
 
         $category = new Category();
@@ -55,6 +62,7 @@ class CategoryController extends Controller
      */
     public function update(UpdateCategoryRequest $request, Category $category)
     {
+        $this->authorize('update', Product::class);
 
         $category->name = $request->name;
         $category->save();
@@ -70,6 +78,7 @@ class CategoryController extends Controller
      */
     public function destroy(Category $category)
     {
+        $this->authorize('delete', Product::class);
 
         $category->delete();
 

--- a/app/Http/Controllers/Api/V1/ClientController.php
+++ b/app/Http/Controllers/Api/V1/ClientController.php
@@ -122,7 +122,9 @@ class ClientController extends Controller
     {
         $this->authorize('update', Client::class);
 
-        $client->update($request->all());
+        // SEGURIDAD: nunca aceptar organization_id del request (mass-assignment
+        // cross-tenant). El tenant se fija server-side al crear.
+        $client->update($request->except(['organization_id']));
         return response(
             new ClientResource($client),
             Response::HTTP_OK

--- a/app/Http/Controllers/Api/V1/ClientController.php
+++ b/app/Http/Controllers/Api/V1/ClientController.php
@@ -61,7 +61,13 @@ class ClientController extends Controller
         if ($request->has('store_id')) {
             $order = $request->query('order', 'asc');
             $store = $request->query('store_id');
-    
+
+            // SEGURIDAD: un usuario restringido no puede pedir los clientes de una
+            // tienda que no tiene asignada (null = ve todas: owner o store.index).
+            $allowedStoreIds = Auth::user()->allowedStoreIds();
+            if ($allowedStoreIds !== null && !in_array($store, $allowedStoreIds, true)) {
+                return response()->json(['message' => 'No autorizado para esta tienda.'], Response::HTTP_FORBIDDEN);
+            }
 
             //get clients for a specific store, store and client are related many to many
             $clients = Client::whereHas('stores', function ($query) use ($store) {

--- a/app/Http/Controllers/Api/V1/CreditController.php
+++ b/app/Http/Controllers/Api/V1/CreditController.php
@@ -265,19 +265,23 @@ class CreditController extends Controller
 
         $orgID = Auth::user()->organization_id;
 
-        $detail = CreditDetail::whereHas('credit', function ($q) use ($orgID) {
-            $q->where('organization_id', $orgID);
-        })->find($id);
+        // SEGURIDAD (TOCTOU): antes voided_at se chequeaba FUERA de la transacción
+        // y solo se bloqueaba la fila credit -> dos anulaciones concurrentes
+        // restauraban la deuda dos veces. Ahora el detalle se bloquea
+        // (lockForUpdate) y se re-chequea voided_at DENTRO de la transacción.
+        $result = DB::transaction(function () use ($id, $orgID, $request) {
+            $detail = CreditDetail::whereHas('credit', function ($q) use ($orgID) {
+                $q->where('organization_id', $orgID);
+            })->lockForUpdate()->find($id);
 
-        if (!$detail) {
-            return response()->json(['message' => 'Abono no encontrado.'], Response::HTTP_NOT_FOUND);
-        }
+            if (!$detail) {
+                return ['status' => Response::HTTP_NOT_FOUND, 'message' => 'Abono no encontrado.', 'credit_id' => null];
+            }
 
-        if ($detail->voided_at) {
-            return response()->json(['message' => 'Este abono ya fue anulado.'], Response::HTTP_CONFLICT);
-        }
+            if ($detail->voided_at) {
+                return ['status' => Response::HTTP_CONFLICT, 'message' => 'Este abono ya fue anulado.', 'credit_id' => $detail->credit_id];
+            }
 
-        DB::transaction(function () use ($detail, $orgID, $request) {
             $credit = Credit::where('id', $detail->credit_id)
                 ->where('organization_id', $orgID)
                 ->lockForUpdate()
@@ -297,9 +301,15 @@ class CreditController extends Controller
             $detail->voided_by = Auth::id();
             $detail->void_reason = $request->input('reason');
             $detail->save();
+
+            return ['status' => Response::HTTP_OK, 'message' => null, 'credit_id' => $detail->credit_id];
         });
 
-        $credit = Credit::where('id', $detail->credit_id)->where('organization_id', $orgID)->first();
+        if ($result['status'] !== Response::HTTP_OK) {
+            return response()->json(['message' => $result['message']], $result['status']);
+        }
+
+        $credit = Credit::where('id', $result['credit_id'])->where('organization_id', $orgID)->first();
 
         return response()->json([
             'message' => 'Abono anulado. La deuda del crédito fue restaurada.',

--- a/app/Http/Controllers/Api/V1/DashboardController.php
+++ b/app/Http/Controllers/Api/V1/DashboardController.php
@@ -19,6 +19,12 @@ class DashboardController extends Controller
 {
     public function metrics(Request $request)
     {
+        // SEGURIDAD: el dashboard expone finanzas org-wide. Gate con report.index
+        // (owner/manager lo tienen; un cajero no) para no exponerlas a cualquier rol.
+        if (!Auth::user()->can('report.index')) {
+            return response()->json(['message' => 'No autorizado.'], 403);
+        }
+
         $storeId = $request->query('store_id');
         $refresh = $request->query('refresh') === 'true';
         $dateFrom = $request->query('date_from');
@@ -272,6 +278,11 @@ class DashboardController extends Controller
 
     public function chart(Request $request)
     {
+        // SEGURIDAD: mismo gate que metrics() (finanzas org-wide).
+        if (!Auth::user()->can('report.index')) {
+            return response()->json(['message' => 'No autorizado.'], 403);
+        }
+
         $metric = $request->query('metric', 'sales');
         $range = $request->query('range', '6m');
         $freq = $request->query('freq', 'monthly');

--- a/app/Http/Controllers/Api/V1/InventoryController.php
+++ b/app/Http/Controllers/Api/V1/InventoryController.php
@@ -276,7 +276,8 @@ class InventoryController extends Controller
             ? $request->store_ids 
             : ($request->store_id ? (array) $request->store_id : null);
 
-        $updateData = $request->all();
+        // SEGURIDAD: no aceptar organization_id del request (mass-assignment cross-tenant).
+        $updateData = $request->except(['organization_id']);
         if ($storeIds !== null) {
             $updateData['store_id'] = count($storeIds) > 0 ? $storeIds[0] : null;
         }

--- a/app/Http/Controllers/Api/V1/InventoryController.php
+++ b/app/Http/Controllers/Api/V1/InventoryController.php
@@ -330,7 +330,14 @@ class InventoryController extends Controller
 
     public function getProductByStore(Store $store, Request $request){
         $this->authorize('viewAny', Inventory::class);
-            
+
+        // SEGURIDAD: un usuario restringido no puede consultar el stock/precios de
+        // una tienda que no tiene asignada (null = ve todas).
+        $allowedStoreIds = Auth::user()->allowedStoreIds();
+        if ($allowedStoreIds !== null && !in_array($store->id, $allowedStoreIds, true)) {
+            return response()->json(['message' => 'No autorizado para esta tienda.'], Response::HTTP_FORBIDDEN);
+        }
+
         $search = $request->query('search');
 
         $inventoryDetails = InventoryDetail::whereHas('inventory', function ($q) use ($store) {
@@ -359,7 +366,12 @@ class InventoryController extends Controller
         $this->authorize('viewAny', Inventory::class);
 
         $orgId = Auth::user()->organization_id;
-        $inventory = InventoryDetail::where('inventory_id', $request->inventory_id)
+
+        // SEGURIDAD: resolver el inventory por el modelo tenant-scoped
+        // (Multitenantable) -> 404 si pertenece a otro tenant. Antes se consultaba
+        // InventoryDetail por un inventory_id crudo, sin scope de organización.
+        $inventoryModel = Inventory::findOrFail($request->inventory_id);
+        $inventory = InventoryDetail::where('inventory_id', $inventoryModel->id)
             ->get();
 
     //    $newData = new InventoryExportCollection($inventory); 

--- a/app/Http/Controllers/Api/V1/InvoiceController.php
+++ b/app/Http/Controllers/Api/V1/InvoiceController.php
@@ -49,6 +49,17 @@ class InvoiceController extends Controller
 
         $query = Invoice::where('organization_id', $orgId);
 
+        // SEGURIDAD: restringir a las tiendas asignadas del usuario. null = ve todas
+        // (owner o store.index). Antes solo se filtraba por organization_id, así que
+        // un usuario de la tienda A veía las ventas de todas las tiendas.
+        $allowedStoreIds = Auth::user()->allowedStoreIds();
+        if ($allowedStoreIds !== null) {
+            if ($store_id !== null && !in_array($store_id, $allowedStoreIds, true)) {
+                return response()->json(['message' => 'No autorizado para esta tienda.'], Response::HTTP_FORBIDDEN);
+            }
+            $query->whereIn('store_id', $allowedStoreIds);
+        }
+
         // Agregar filtro por tienda
         if ($store_id) {
             $query->where('store_id', $store_id);
@@ -687,13 +698,23 @@ class InvoiceController extends Controller
         $this->authorize('viewAny', Invoice::class);
 
         $orgId = Auth::user()->organization_id;
-        $invoices = Invoice::where('organization_id', $orgId)
-            ->where('store_id', $request->store_id)
-            ->get();
 
-            
+        // SEGURIDAD: no exportar ventas de una tienda que no es del usuario.
+        $allowedStoreIds = Auth::user()->allowedStoreIds();
+        if ($allowedStoreIds !== null && $request->store_id !== null
+            && !in_array($request->store_id, $allowedStoreIds, true)) {
+            return response()->json(['message' => 'No autorizado para esta tienda.'], Response::HTTP_FORBIDDEN);
+        }
 
-        
+        $exportQuery = Invoice::where('organization_id', $orgId);
+        if ($allowedStoreIds !== null) {
+            $exportQuery->whereIn('store_id', $allowedStoreIds);
+        }
+        if ($request->store_id) {
+            $exportQuery->where('store_id', $request->store_id);
+        }
+        $invoices = $exportQuery->get();
+
        return Excel::download(new InvoiceExport($invoices), 'reporte_invoices.xlsx');
     }
 }

--- a/app/Http/Controllers/Api/V1/LandingAdminController.php
+++ b/app/Http/Controllers/Api/V1/LandingAdminController.php
@@ -16,7 +16,7 @@ class LandingAdminController extends Controller
     public function uploadMedia(Request $request)
     {
         $request->validate([
-            'file' => 'required|image|mimes:jpeg,png,jpg,gif,svg,webp|max:5120',
+            'file' => 'required|image|mimes:jpeg,png,jpg,gif,webp|max:5120',
         ]);
 
         $file = $request->file('file');

--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -250,7 +250,12 @@ class OrganizationController extends Controller
 
         $this->validateUniqueFields($request, $organization->id);
 
+        // SEGURIDAD: si viene un archivo de logo, validarlo antes de escribirlo en
+        // el disco público (nginx ejecuta *.php ahí; svg puede llevar scripts).
         if ($request->hasFile('logo')) {
+            $request->validate([
+                'logo' => 'image|mimes:jpeg,jpg,png,webp,gif|max:5120',
+            ]);
             $organization->logo = $request->file('logo')->store('organizationLogo', 'public');
         }
 

--- a/app/Http/Controllers/Api/V1/PasswordResetController.php
+++ b/app/Http/Controllers/Api/V1/PasswordResetController.php
@@ -47,7 +47,8 @@ class PasswordResetController extends Controller
         }
 
         // Generar código de 6 dígitos
-        $code = (string) rand(100000, 999999);
+        // SEGURIDAD: random_int es criptográficamente seguro (rand() es predecible).
+        $code = (string) random_int(100000, 999999);
 
         // Eliminar tokens previos de este correo
         DB::connection('central')

--- a/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/Http/Controllers/Api/V1/ProductController.php
@@ -197,7 +197,8 @@ class ProductController extends Controller
         ]);
 
         $oldPrice = $product->price;
-        $data = $request->all();
+        // SEGURIDAD: no aceptar organization_id del request (mass-assignment cross-tenant).
+        $data = $request->except(['organization_id']);
 
         // Si se edita para una sucursal, no modificamos el precio base global
         if ($request->filled('inventory')) {

--- a/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/Http/Controllers/Api/V1/ProductController.php
@@ -298,8 +298,17 @@ class ProductController extends Controller
 
     public function addImageToProduct(Request $request, Product $product)
     {
+        $this->authorize('update', $product);
 
-        // FIXME: Manejo directo de archivos - debería usar endpoint dedicado de upload
+        // SEGURIDAD: validar tipo/tamaño real. El disco 'public' es servido por
+        // nginx, que ejecuta cualquier *.php bajo /var/www/public. La regla
+        // 'image' + whitelist de mimes (sin svg) impide que se escriba un
+        // archivo ejecutable/scriptable; la extensión almacenada se deriva del
+        // contenido validado.
+        $request->validate([
+            'image' => 'required|image|mimes:jpeg,jpg,png,webp,gif|max:5120',
+        ]);
+
         if ($request->hasFile('image')) {
             $product->image = $request->file('image')->store('productsImages', 'public');
         }

--- a/app/Http/Controllers/Api/V1/ReportController.php
+++ b/app/Http/Controllers/Api/V1/ReportController.php
@@ -94,11 +94,11 @@ class ReportController extends Controller
             return response()->json(['message' => 'Unauthorized'], 403);
         }
 
-        if (!$report->file_path || !Storage::disk('public')->exists($report->file_path)) {
+        if (!$report->file_path || !Storage::disk('local')->exists($report->file_path)) {
             return response()->json(['message' => 'File not found'], 404);
         }
 
-        return Storage::disk('public')->download($report->file_path, $report->name . '.pdf');
+        return Storage::disk('local')->download($report->file_path, $report->name . '.pdf');
     }
 
     /**
@@ -115,8 +115,8 @@ class ReportController extends Controller
         }
 
         // Eliminar archivo físico si existe
-        if ($report->file_path && Storage::disk('public')->exists($report->file_path)) {
-            Storage::disk('public')->delete($report->file_path);
+        if ($report->file_path && Storage::disk('local')->exists($report->file_path)) {
+            Storage::disk('local')->delete($report->file_path);
         }
 
         $report->delete();

--- a/app/Http/Controllers/Api/V1/RoleController.php
+++ b/app/Http/Controllers/Api/V1/RoleController.php
@@ -56,13 +56,20 @@ class RoleController extends Controller
             return response()->json(['message' => 'Role name already exists'], Response::HTTP_CONFLICT);
         }
 
+        // SEGURIDAD: no permitir otorgar permisos que el actor no posee (evita
+        // que un sub-rol con role.store se auto-fabrique un rol con permisos
+        // superiores a los suyos).
+        $this->assertCanGrantPermissions($request->permissions ?? []);
+
         $orgID = Auth::user()->organization_id;
-        $request->merge(['organization_id' => $orgID]);
-        $role = Role::create($request->all());
+        // Campos server-side explícitos: organization_id nunca desde el request.
+        $role = Role::create([
+            'name' => $request->name,
+            'guard_name' => $request->guard_name,
+            'organization_id' => $orgID,
+        ]);
 
-
-        $permissions = $request->permissions;
-        $role->syncPermissions($permissions);
+        $role->syncPermissions($request->permissions);
         return response()->json(new RoleResource($role), Response::HTTP_CREATED);
     }
 
@@ -79,7 +86,12 @@ class RoleController extends Controller
         if (Role::where('name', $request->name)->where('organization_id', Auth::user()->organization_id)->where('uuid', '!=', $role->uuid)->exists()) {
             return response()->json(['message' => 'Role name already exists'], Response::HTTP_CONFLICT);
         }
-        $role->update($request->all());
+
+        // SEGURIDAD: mismo límite de subconjunto que en store().
+        $this->assertCanGrantPermissions($request->permissions ?? []);
+
+        // Whitelist explícito: nunca aceptar organization_id del request.
+        $role->update(['name' => $request->name]);
         $role->syncPermissions($request->permissions);
         return response()->json(new RoleResource($role), Response::HTTP_OK);
     }
@@ -88,7 +100,27 @@ class RoleController extends Controller
     {
         $this->authorize('delete', $role);
 
+        // SEGURIDAD: Role vive en la conexión 'central' y NO tiene global scope
+        // de tenant, así que el route-binding resuelve roles de cualquier
+        // organización. Sin este chequeo un admin borra el rol de otro tenant.
+        if ($role->organization_id != Auth::user()->organization_id) {
+            return response()->json(['message' => 'Role not found'], Response::HTTP_NOT_FOUND);
+        }
+
         $role->delete();
         return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Rechaza cualquier permiso solicitado que el usuario autenticado no posea.
+     * El Owner (que tiene todos los permisos) pasa siempre.
+     */
+    private function assertCanGrantPermissions(array $requested): void
+    {
+        $ownPermissions = Auth::user()->getAllPermissions()->pluck('name')->all();
+        $notAllowed = array_values(array_diff($requested, $ownPermissions));
+        if (!empty($notAllowed)) {
+            abort(Response::HTTP_FORBIDDEN, 'No puedes otorgar permisos que tú no posees: ' . implode(', ', $notAllowed));
+        }
     }
 }

--- a/app/Http/Controllers/Api/V1/SocialAuthController.php
+++ b/app/Http/Controllers/Api/V1/SocialAuthController.php
@@ -5,48 +5,50 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
-use Laravel\Socialite\Facades\Socialite;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 use App\Services\GoogleOAuthConfigurator;
+use App\Services\GoogleIdTokenVerifier;
 
 class SocialAuthController extends Controller
 {
+    public function __construct(private GoogleIdTokenVerifier $idTokenVerifier)
+    {
+    }
+
     /**
-     * Autenticar o registrar un usuario usando Google OAuth (Token-based).
+     * Autenticar o registrar un usuario usando Google OAuth.
+     *
+     * SEGURIDAD: exige un *ID token* de Google (JWT firmado), NO un access token.
+     * El ID token se verifica del lado del servidor (firma + aud + iss +
+     * email_verified) para cerrar el confused-deputy que permitía usar un
+     * access token de otra app para tomar la cuenta.
      */
     public function handleGoogle(Request $request)
     {
         $request->validate([
-            'token' => 'required|string', // Token de acceso o ID token enviado desde el frontend
+            'token' => 'required|string', // ID token (JWT) emitido por Google para esta app
             'device_name' => 'required|string',
         ]);
 
-        // Aplicar la configuración dinámica guardada en BD
+        // Aplicar la configuración dinámica guardada en BD (client_id/secret)
         GoogleOAuthConfigurator::applyConfiguration();
 
         try {
-            // Obtener datos del usuario desde Google usando el token proveído
-            $googleUser = Socialite::driver('google')->userFromToken($request->token);
-        } catch (\Exception $e) {
+            $googleUser = $this->idTokenVerifier->verify($request->token);
+        } catch (\Throwable $e) {
             return response()->json([
-                'message' => 'Token de Google inválido o expirado.',
+                'message' => 'Token de Google inválido o no autorizado para esta aplicación.',
                 'error' => $e->getMessage()
             ], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
-        if (!$googleUser || !$googleUser->getEmail()) {
-            return response()->json([
-                'message' => 'No se pudo obtener información del perfil de Google.'
-            ], Response::HTTP_UNPROCESSABLE_ENTITY);
-        }
-
-        $email = $googleUser->getEmail();
-        $googleId = $googleUser->getId();
-        $avatar = $googleUser->getAvatar();
-        $name = $googleUser->getName() ?? 'Usuario Google';
+        $email = $googleUser['email'];
+        $googleId = $googleUser['sub'];
+        $avatar = $googleUser['picture'];
+        $name = $googleUser['name'] ?? 'Usuario Google';
 
         // 1. Buscar si el usuario ya está vinculado a este google_id
         $user = User::where('google_id', $googleId)->first();
@@ -154,28 +156,22 @@ class SocialAuthController extends Controller
     public function linkGoogle(Request $request)
     {
         $request->validate([
-            'token' => 'required|string',
+            'token' => 'required|string', // ID token (JWT) de Google
         ]);
 
         GoogleOAuthConfigurator::applyConfiguration();
 
         try {
-            $googleUser = Socialite::driver('google')->userFromToken($request->token);
-        } catch (\Exception $e) {
+            $googleUser = $this->idTokenVerifier->verify($request->token);
+        } catch (\Throwable $e) {
             return response()->json([
-                'message' => 'Token de Google inválido o expirado.',
+                'message' => 'Token de Google inválido o no autorizado para esta aplicación.',
                 'error' => $e->getMessage()
             ], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
-        if (!$googleUser || !$googleUser->getEmail()) {
-            return response()->json([
-                'message' => 'No se pudo obtener información del perfil de Google.'
-            ], Response::HTTP_UNPROCESSABLE_ENTITY);
-        }
-
-        $googleId = $googleUser->getId();
-        $avatar = $googleUser->getAvatar();
+        $googleId = $googleUser['sub'];
+        $avatar = $googleUser['picture'];
         $currentUser = $request->user();
 
         // Verificar si la cuenta de Google ya está vinculada a otro usuario

--- a/app/Http/Controllers/Api/V1/StoreController.php
+++ b/app/Http/Controllers/Api/V1/StoreController.php
@@ -178,7 +178,13 @@ class StoreController extends Controller
     {
         $this->authorize('update', $store);
 
-        // FIXME: Manejo directo de archivos - debería usar endpoint dedicado de upload
+        // SEGURIDAD: validar tipo/tamaño real antes de escribir en el disco
+        // público (nginx ejecuta *.php ahí). 'image' + mimes sin svg bloquea
+        // ejecutables y svg con scripts.
+        $request->validate([
+            'print_logo' => 'required|image|mimes:jpeg,jpg,png,webp,gif|max:5120',
+        ]);
+
         if ($request->hasFile('print_logo')) {
             $store->print_logo = $request->file('print_logo')->store('stote_print_logo', 'public');
         }

--- a/app/Http/Controllers/Api/V1/StoreController.php
+++ b/app/Http/Controllers/Api/V1/StoreController.php
@@ -136,7 +136,12 @@ class StoreController extends Controller
         }
 
 
-        $store->update($request->all());
+        // SEGURIDAD: nunca aceptar del request organization_id (cross-tenant) ni la
+        // numeración fiscal / estado (invoice_number/prefix/status/user_id): esos
+        // los controla el servidor. $request->all() los dejaba manipulables.
+        $store->update($request->except([
+            'organization_id', 'invoice_number', 'invoice_prefix', 'status', 'user_id',
+        ]));
 
         return response(
             new StoreResource($store),
@@ -221,7 +226,10 @@ class StoreController extends Controller
     {
         $this->authorize('update', $store);
 
-        $store->update($request->all());
+        // SEGURIDAD: mismo blindaje que update() contra mass-assignment.
+        $store->update($request->except([
+            'organization_id', 'invoice_number', 'invoice_prefix', 'status', 'user_id',
+        ]));
 
         return response(
             new StoreResource($store),

--- a/app/Http/Controllers/Api/V1/SupplierController.php
+++ b/app/Http/Controllers/Api/V1/SupplierController.php
@@ -127,7 +127,8 @@ class SupplierController extends Controller
             return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
         }
 
-        $supplier->update($request->all());
+        // SEGURIDAD: no aceptar organization_id del request.
+        $supplier->update($request->except(['organization_id']));
 
         return response(
             new SupplierResource($supplier),
@@ -216,7 +217,14 @@ class SupplierController extends Controller
             return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
         }
 
-        $contact->update($contactRequest->all());
+        // SEGURIDAD: SupplierContact no tiene global scope de tenant, así que el
+        // route-binding resuelve contactos de cualquier supplier/tenant. Exigir
+        // que el contacto pertenezca a ESTE supplier.
+        if ($contact->supplier_id !== $supplier->id) {
+            return response()->json(['message' => 'Contact not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $contact->update($contactRequest->except(['organization_id', 'supplier_id']));
 
         return response(
             $contact,
@@ -236,9 +244,10 @@ class SupplierController extends Controller
             return response()->json(['message' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
         }
 
-
-
-
+        // SEGURIDAD: el contacto debe pertenecer a este supplier (ver contactUpdate).
+        if ($contact->supplier_id !== $supplier->id) {
+            return response()->json(['message' => 'Contact not found'], Response::HTTP_NOT_FOUND);
+        }
 
         $contact->delete();
 

--- a/app/Http/Controllers/Api/V1/TagController.php
+++ b/app/Http/Controllers/Api/V1/TagController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Models\Tag;
+use App\Models\Product;
 
 
 use App\Http\Requests\StoreTagRequest;
@@ -13,11 +14,15 @@ use App\Http\Resources\TagResource;
 
 
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class TagController extends Controller
 {
+    // SEGURIDAD: reusa product.* — antes no autorizaba nada.
+    use AuthorizesRequests;
+
     /**
      * Display a listing of the resource.
      */
@@ -35,6 +40,7 @@ class TagController extends Controller
      */
     public function store(StoreTagRequest $request)
     {
+        $this->authorize('create', Product::class);
         $orgId = Auth::user()->organization_id;
 
         $Tag = new Tag();
@@ -55,6 +61,7 @@ class TagController extends Controller
      */
     public function update(UpdateTagRequest $request, Tag $Tag)
     {
+        $this->authorize('update', Product::class);
 
         $Tag->name = $request->name;
         $Tag->save();
@@ -70,6 +77,7 @@ class TagController extends Controller
      */
     public function destroy(Tag $Tag)
     {
+        $this->authorize('delete', Product::class);
 
         $Tag->delete();
 

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -248,6 +248,18 @@ class UserController extends Controller
             return response()->json(['message' => 'Role does not belong to your organization'], Response::HTTP_FORBIDDEN);
         }
 
+        // SEGURIDAD: no permitir asignar (a otro o a sí mismo) un rol con permisos
+        // que el actor no posee -> si no, un usuario con user.update se auto-asigna
+        // el rol Owner y escala privilegios.
+        $rolePermissions = $role->permissions->pluck('name')->all();
+        $ownPermissions = Auth::user()->getAllPermissions()->pluck('name')->all();
+        $escalated = array_values(array_diff($rolePermissions, $ownPermissions));
+        if (!empty($escalated)) {
+            return response()->json([
+                'message' => 'No puedes asignar un rol con más permisos que los tuyos.'
+            ], Response::HTTP_FORBIDDEN);
+        }
+
         $user->roles()->detach();
         $user->assignRole($role);
         $user->update(['role_id' => $role->uuid]);

--- a/app/Http/Controllers/Api/V1/WooCommerceIntegrationController.php
+++ b/app/Http/Controllers/Api/V1/WooCommerceIntegrationController.php
@@ -7,6 +7,7 @@ use App\Models\WooCommerceIntegration;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
+use Symfony\Component\HttpFoundation\Response;
 
 class WooCommerceIntegrationController extends Controller
 {
@@ -15,6 +16,8 @@ class WooCommerceIntegrationController extends Controller
      */
     public function index()
     {
+        $this->assertOwner();
+
         $orgId = Auth::user()->organization_id;
         $integration = WooCommerceIntegration::where('organization_id', $orgId)->first();
 
@@ -36,6 +39,8 @@ class WooCommerceIntegrationController extends Controller
      */
     public function store(Request $request)
     {
+        $this->assertOwner();
+
         $request->validate([
             'store_id' => 'required|string|exists:stores,id',
             'inventory_id' => 'required|string|exists:inventories,id',
@@ -44,6 +49,9 @@ class WooCommerceIntegrationController extends Controller
             'woo_consumer_secret' => 'required|string',
             'status' => 'nullable|boolean'
         ]);
+
+        // SEGURIDAD (SSRF): validar que la URL no apunte a la red interna.
+        $this->assertSafeWooUrl($request->woo_store_url);
 
         $orgId = Auth::user()->organization_id;
 
@@ -70,19 +78,26 @@ class WooCommerceIntegrationController extends Controller
      */
     public function testConnection(Request $request)
     {
+        $this->assertOwner();
+
         $request->validate([
             'woo_store_url' => 'required|url',
             'woo_consumer_key' => 'required|string',
             'woo_consumer_secret' => 'required|string',
         ]);
 
+        // SEGURIDAD (SSRF): bloquear direcciones internas antes de la petición.
+        $this->assertSafeWooUrl($request->woo_store_url);
+
         $url = rtrim($request->woo_store_url, '/');
         $key = $request->woo_consumer_key;
         $secret = $request->woo_consumer_secret;
 
         try {
-            // Realizar una petición simple al endpoint de system status
+            // Realizar una petición simple al endpoint de system status.
+            // Sin seguir redirects (evita rebote a un host interno).
             $response = Http::timeout(10)
+                ->withOptions(['allow_redirects' => false])
                 ->withBasicAuth($key, $secret)
                 ->get($url . '/wp-json/wc/v3/system_status');
 
@@ -93,18 +108,76 @@ class WooCommerceIntegrationController extends Controller
                 ]);
             }
 
+            // SEGURIDAD: no reflejar el body de la respuesta (fuga de datos internos vía SSRF).
             return response()->json([
                 'success' => false,
                 'message' => 'Error de conexión. Respuesta HTTP: ' . $response->status(),
-                'details' => $response->json()
             ], 400);
 
         } catch (\Throwable $e) {
+            // SEGURIDAD: no reflejar el mensaje de la excepción (fuga de red interna).
+            report($e);
             return response()->json([
                 'success' => false,
                 'message' => 'No se pudo establecer conexión con el servidor. Valida la URL y que no haya restricciones de firewall.',
-                'error' => $e->getMessage()
             ], 500);
+        }
+    }
+
+    /**
+     * Solo el propietario de la organización gestiona integraciones (contienen
+     * credenciales de la API de WooCommerce).
+     */
+    private function assertOwner(): void
+    {
+        $user = Auth::user();
+        if (!$user->organization || $user->id !== $user->organization->owner_id) {
+            abort(Response::HTTP_FORBIDDEN, 'Solo el propietario puede gestionar la integración de WooCommerce.');
+        }
+    }
+
+    /**
+     * Rechaza URLs que apunten a la red interna / metadata cloud (SSRF), que
+     * traigan credenciales, o query/fragment (que neutralizarían el path fijo).
+     */
+    private function assertSafeWooUrl(string $rawUrl): void
+    {
+        $parts = parse_url($rawUrl);
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'URL de la tienda inválida.');
+        }
+        if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'La URL debe usar http(s).');
+        }
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'La URL no puede contener credenciales.');
+        }
+        if (isset($parts['query']) || isset($parts['fragment'])) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'La URL no puede contener query ni fragmento.');
+        }
+
+        $host = $parts['host'];
+        $ips = [];
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = [$host];
+        } else {
+            $ips = gethostbynamel($host) ?: [];
+            $aaaa = @dns_get_record($host, DNS_AAAA) ?: [];
+            foreach ($aaaa as $rec) {
+                if (!empty($rec['ipv6'])) {
+                    $ips[] = $rec['ipv6'];
+                }
+            }
+        }
+        if (empty($ips)) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'No se pudo resolver el host de la tienda.');
+        }
+        foreach ($ips as $ip) {
+            // NO_PRIV_RANGE + NO_RES_RANGE bloquean 10/8, 172.16/12, 192.168/16,
+            // 127/8 (loopback), 169.254/16 (metadata cloud), fc00::/7, etc.
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'La URL apunta a una dirección de red no permitida.');
+            }
         }
     }
 }

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -26,7 +26,8 @@ class StoreProductRequest extends FormRequest
             'barcode' => ['string', 'max:255', 'unique:products,barcode', 'nullable'],
             'name' => ['required', 'string', 'max:255'],
             'description' => ['string'],
-            'image' => 'image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+            // SEGURIDAD: sin 'svg' (un SVG puede llevar <script>/onload y se sirve inline).
+            'image' => 'image|mimes:jpeg,png,jpg,webp,gif|max:2048',
             'cost' => ['required', 'numeric'],
             'price' => ['required', 'numeric'],
             'min_stock' => ['numeric'],

--- a/app/Http/Requests/StoreStoreRequest.php
+++ b/app/Http/Requests/StoreStoreRequest.php
@@ -34,6 +34,8 @@ class StoreStoreRequest extends FormRequest
             'ruc' => ['nullable', 'string', 'max:255'],
             'store_currency' => ['string', 'max:3'],
             'print_json' => ['nullable', 'array'],
+            // SEGURIDAD: el logo se guarda en el disco público servido por nginx.
+            'print_logo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,webp,gif', 'max:5120'],
 
         ];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -89,4 +89,22 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->belongsToMany(Store::class, 'user_store')->using(UserStore::class);
     }
+
+    /**
+     * IDs de las tiendas que este usuario puede ver/consultar.
+     *
+     * Devuelve null cuando el usuario NO está restringido por tienda: el owner de
+     * la organización o cualquiera con permiso 'store.index' ve todas (misma regla
+     * que StoreController::index). Para el resto, devuelve solo sus tiendas
+     * asignadas — así las listas/exports no filtran solo por organization_id
+     * (lo que dejaba a un usuario de la tienda A ver las ventas de la tienda B).
+     */
+    public function allowedStoreIds(): ?array
+    {
+        $isOwner = $this->organization && $this->id === $this->organization->owner_id;
+        if ($isOwner || $this->hasPermissionTo('store.index')) {
+            return null;
+        }
+        return $this->stores()->pluck('stores.id')->all();
+    }
 }

--- a/app/Models/WooCommerceIntegration.php
+++ b/app/Models/WooCommerceIntegration.php
@@ -25,6 +25,12 @@ class WooCommerceIntegration extends Model
         'status',
     ];
 
+    // SEGURIDAD: el secret no debe salir en respuestas JSON (antes cualquier rol
+    // de la org lo leía en claro vía GET /woocommerce/integration).
+    protected $hidden = [
+        'woo_consumer_secret',
+    ];
+
     protected $casts = [
         'status' => 'boolean',
     ];

--- a/app/Notifications/DynamicSystemNotification.php
+++ b/app/Notifications/DynamicSystemNotification.php
@@ -140,8 +140,11 @@ class DynamicSystemNotification extends Notification
                     $formattedNum = number_format((float)$val, 2);
                     $val = $currency ? $currency . ' ' . $formattedNum : $formattedNum;
                 }
+                // SEGURIDAD: el body se renderiza como HTML ({!! $body !!}).
+                // Escapar el VALOR inyectado (no el template) evita inyección de
+                // HTML/phishing con datos del tenant (client_name, etc.).
                 $subject = str_replace($placeholder, (string)$val, $subject);
-                $body = str_replace($placeholder, (string)$val, $body);
+                $body = str_replace($placeholder, e((string)$val), $body);
             }
         }
 

--- a/app/Services/GoogleIdTokenVerifier.php
+++ b/app/Services/GoogleIdTokenVerifier.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Verifica un ID token de Google (JWT firmado) del lado del servidor.
+ *
+ * Antes, el login usaba Socialite::userFromToken() con un *access token*, que
+ * Google acepta sin importar para qué app fue emitido → confused-deputy: un
+ * access token emitido para CUALQUIER otra app servía para autenticarse aquí.
+ *
+ * Esta clase exige un ID token y valida:
+ *   - firma (contra las claves públicas de Google / JWKS)
+ *   - exp / iat (via Firebase\JWT)
+ *   - aud === nuestro client_id  (cierra el confused-deputy)
+ *   - iss === accounts.google.com
+ *   - email_verified === true
+ */
+class GoogleIdTokenVerifier
+{
+    private const CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    private const CERTS_CACHE_KEY = 'google_oauth_jwks';
+    private const ALLOWED_ISS = ['accounts.google.com', 'https://accounts.google.com'];
+
+    /**
+     * @return array{sub:string,email:string,name:?string,picture:?string}
+     * @throws RuntimeException si el token no es válido para esta app.
+     */
+    public function verify(string $idToken): array
+    {
+        $clientId = config('services.google.client_id');
+        if (empty($clientId)) {
+            throw new RuntimeException('Google OAuth no está configurado (client_id ausente).');
+        }
+
+        try {
+            $keys = JWK::parseKeySet($this->fetchCerts());
+            // JWT::decode valida firma + exp + nbf/iat.
+            $claims = (array) JWT::decode($idToken, $keys);
+        } catch (\Throwable $e) {
+            throw new RuntimeException('ID token de Google inválido o expirado.', 0, $e);
+        }
+
+        // aud: cierra el confused-deputy — el token debe haber sido emitido para NUESTRO client_id.
+        $aud = $claims['aud'] ?? null;
+        if ($aud !== $clientId) {
+            throw new RuntimeException('El ID token no fue emitido para esta aplicación.');
+        }
+
+        // iss
+        $iss = $claims['iss'] ?? null;
+        if (!in_array($iss, self::ALLOWED_ISS, true)) {
+            throw new RuntimeException('Emisor del ID token no confiable.');
+        }
+
+        // email verificado
+        $email = $claims['email'] ?? null;
+        $emailVerified = filter_var($claims['email_verified'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        if (empty($email) || !$emailVerified) {
+            throw new RuntimeException('El correo de Google no está verificado.');
+        }
+
+        $sub = $claims['sub'] ?? null;
+        if (empty($sub)) {
+            throw new RuntimeException('El ID token no contiene un identificador de usuario.');
+        }
+
+        return [
+            'sub' => (string) $sub,
+            'email' => (string) $email,
+            'name' => isset($claims['name']) ? (string) $claims['name'] : null,
+            'picture' => isset($claims['picture']) ? (string) $claims['picture'] : null,
+        ];
+    }
+
+    /**
+     * Descarga (y cachea ~1h) el JWKS de Google. Respeta Cache-Control si viene.
+     */
+    private function fetchCerts(): array
+    {
+        return Cache::remember(self::CERTS_CACHE_KEY, now()->addMinutes(60), function () {
+            $response = Http::timeout(8)->get(self::CERTS_URL);
+            if (!$response->successful()) {
+                throw new RuntimeException('No se pudieron obtener las claves públicas de Google.');
+            }
+            return $response->json();
+        });
+    }
+}

--- a/app/Services/MailConfigurator.php
+++ b/app/Services/MailConfigurator.php
@@ -110,8 +110,9 @@ class MailConfigurator
 
         foreach ($data as $key => $val) {
             $placeholder = '{' . $key . '}';
-            $subject = str_replace($placeholder, $val, $subject);
-            $body = str_replace($placeholder, $val, $body);
+            // SEGURIDAD: escapar el valor inyectado en el body HTML (ver DynamicSystemNotification).
+            $subject = str_replace($placeholder, (string) $val, $subject);
+            $body = str_replace($placeholder, e((string) $val), $body);
         }
 
         // 4. Dispatch the mail

--- a/app/Services/Reports/BaseReportStrategy.php
+++ b/app/Services/Reports/BaseReportStrategy.php
@@ -75,7 +75,10 @@ abstract class BaseReportStrategy
             $fileName = 'report_' . $report->id . '_' . time() . '.pdf';
             $filePath = 'reports/' . $fileName;
             
-            Storage::disk('public')->put($filePath, $pdf->output());
+            // SEGURIDAD: disco PRIVADO (local). Antes 'public' dejaba los PDFs
+            // financieros accesibles sin auth en /storage/reports/... Se sirven
+            // solo por ReportController::download (que verifica ownership).
+            Storage::disk('local')->put($filePath, $pdf->output());
 
             // 5. Actualizar el registro como completado
             $report->update([

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,7 +17,15 @@ return Application::configure(basePath: dirname(__DIR__))
         // él para leer X-Forwarded-* → esquema/host reales (links https correctos,
         // enlaces de verificación firmados válidos) y IP real del cliente (para
         // que el throttle por IP no agrupe a todos bajo la IP del proxy).
-        $middleware->trustProxies(at: '*');
+        //
+        // SEGURIDAD: NO confiar en '*' (cualquier upstream podría spoofear
+        // X-Forwarded-For y evadir el throttle por IP). Confiar solo en la red
+        // privada donde vive Traefik; ajustable con TRUSTED_PROXIES (ej. la IP/CIDR
+        // exacta del contenedor del proxy).
+        $trustedProxies = env('TRUSTED_PROXIES', '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7');
+        $middleware->trustProxies(
+            at: array_map('trim', explode(',', $trustedProxies))
+        );
 
         $middleware->alias([
             'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,

--- a/composer.lock
+++ b/composer.lock
@@ -890,16 +890,16 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
-                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/6d4b4eb8500f7a786da8868ba463a71b725a4005",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005",
                 "shasum": ""
             },
             "require": {
@@ -948,9 +948,9 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.6"
             },
-            "time": "2026-03-03T13:54:37+00:00"
+            "time": "2026-07-20T12:29:38+00:00"
         },
         {
             "name": "dompdf/php-font-lib",
@@ -1483,21 +1483,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/promises": "^2.5.2",
                 "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -1591,7 +1591,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -1607,20 +1607,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -1675,7 +1675,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -1691,7 +1691,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -2582,16 +2582,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -2628,7 +2628,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -2685,7 +2685,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -46,7 +46,10 @@ return [
     |
     */
 
-    'expiration' => null,
+    // SEGURIDAD: acotar la vida del token (antes null = infinito). 90 días por
+    // defecto: suficiente para el POS offline sin dejar tokens eternos si se
+    // filtran. Ajustable con SANCTUM_EXPIRATION_MINUTES.
+    'expiration' => (int) env('SANCTUM_EXPIRATION_MINUTES', 60 * 24 * 90),
 
     /*
     |--------------------------------------------------------------------------

--- a/docker/nginx/conf.d/app.conf
+++ b/docker/nginx/conf.d/app.conf
@@ -9,6 +9,16 @@ server {
     # subidas de comprobantes/capturas con el default de 1 MB.
     client_max_body_size 12m;
 
+    # Defensa en profundidad contra RCE por subida de archivos: los uploads de
+    # usuarios viven bajo /storage (symlink a storage/app/public). NUNCA ejecutar
+    # PHP ahí ni permitir MIME-sniffing; servirlos como estáticos. El prefijo ^~
+    # gana a la location regex ~ \.php$ de abajo.
+    location ^~ /storage/ {
+        add_header X-Content-Type-Options "nosniff" always;
+        location ~ \.php$ { return 403; }
+        try_files $uri =404;
+    }
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
@@ -18,8 +28,10 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
     }
-    
+
     location / {
+        add_header X-Content-Type-Options "nosniff" always;
+        try_files $uri $uri/ /index.php?$query_string;
         try_files $uri $uri/ /index.php?$query_string;
         gzip_static on;
     }

--- a/resources/views/admin/landing/index.blade.php
+++ b/resources/views/admin/landing/index.blade.php
@@ -309,7 +309,7 @@
                                         discount: '{{ $plan->discount }}',
                                         is_featured: {{ $plan->is_featured ? 1 : 0 }},
                                         status: '{{ $plan->status }}',
-                                        features: {!! json_encode($plan->features) !!}
+                                        features: @json($plan->features)
                                     })">
                                     Editar
                                 </button>
@@ -398,7 +398,7 @@
     }
 
     // Datos de las secciones precargadas para el editor JSON
-    const rawSections = {!! json_encode($sections) !!};
+    const rawSections = @json($sections);
 
     function loadSectionJson() {
         const key = document.getElementById('section-selector').value;

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,11 +50,13 @@ Route::prefix('v1')->group(function () {
         return response()->json(['ok' => true, 'ts' => now()->timestamp]);
     });
 
-    Route::post('/login', [LoginController::class, 'login']);
-    Route::post('/register', [LoginController::class, 'registerOwner']);
-    Route::post('/forgot-password', [PasswordResetController::class, 'forgotPassword']);
-    Route::post('/reset-password', [PasswordResetController::class, 'resetPassword']);
-    Route::post('/auth/google', [SocialAuthController::class, 'handleGoogle']);
+    // SEGURIDAD: throttle en los endpoints públicos de auth (fuerza bruta / abuso).
+    // Con trustProxies pineado, el límite es por IP real del cliente.
+    Route::post('/login', [LoginController::class, 'login'])->middleware('throttle:10,1');
+    Route::post('/register', [LoginController::class, 'registerOwner'])->middleware('throttle:10,1');
+    Route::post('/forgot-password', [PasswordResetController::class, 'forgotPassword'])->middleware('throttle:6,1');
+    Route::post('/reset-password', [PasswordResetController::class, 'resetPassword'])->middleware('throttle:6,1');
+    Route::post('/auth/google', [SocialAuthController::class, 'handleGoogle'])->middleware('throttle:10,1');
 
     // Reenviar el correo de verificación. Autenticado pero SIN tenant.switch:
     // un usuario recién registrado aún no tiene organización.

--- a/tests/Feature/PasswordResetAndForcedChangeTest.php
+++ b/tests/Feature/PasswordResetAndForcedChangeTest.php
@@ -202,17 +202,16 @@ class PasswordResetAndForcedChangeTest extends TestCase
 
         $this->actingAs($user, 'sanctum');
 
-        // Mockear Socialite
-        $googleUser = \Mockery::mock('Laravel\Socialite\Two\User');
-        $googleUser->shouldReceive('getId')->andReturn('mock_google_id_linked_12345');
-        $googleUser->shouldReceive('getEmail')->andReturn('user_mocked_linked@gmail.com');
-        $googleUser->shouldReceive('getAvatar')->andReturn('https://lh3.googleusercontent.com/a/default-user=s96-c');
-        $googleUser->shouldReceive('getName')->andReturn('Mocked Linked User');
-
-        $provider = \Mockery::mock('Laravel\Socialite\Contracts\Provider');
-        $provider->shouldReceive('userFromToken')->with('mock_token_12345')->andReturn($googleUser);
-
-        \Laravel\Socialite\Facades\Socialite::shouldReceive('driver')->with('google')->andReturn($provider);
+        // Mockear la verificación del ID token de Google (antes se mockeaba
+        // Socialite::userFromToken; ahora se verifica el ID token server-side).
+        $this->mock(\App\Services\GoogleIdTokenVerifier::class, function ($mock) {
+            $mock->shouldReceive('verify')->with('mock_token_12345')->andReturn([
+                'sub' => 'mock_google_id_linked_12345',
+                'email' => 'user_mocked_linked@gmail.com',
+                'name' => 'Mocked Linked User',
+                'picture' => 'https://lh3.googleusercontent.com/a/default-user=s96-c',
+            ]);
+        });
 
         $response = $this->postJson('/api/v1/user/google/link', [
             'token' => 'mock_token_12345'


### PR DESCRIPTION
Endurecimiento de seguridad del backend a partir del análisis multi-agente. Suite de tests en verde (se ajustó el mock del ID token de Google).

## 🔴 P0
- **RCE por subida de archivos**: `addImageToProduct`/`addImageToStore`/logos no validaban tipo/tamaño → un `<?php` se guardaba con extensión `.php` en el disco público que nginx ejecuta. Ahora `image|mimes` (sin svg) + `authorize()`; nginx nunca ejecuta PHP bajo `/storage` + `nosniff`.
- **Toma de cuenta por Google OAuth**: se exige un **ID token** verificado server-side (firma + `aud` + `iss` + `email_verified`) en vez del access token (confused-deputy).

## 🟠 P1
- Role `destroy` cross-tenant + escalada de privilegios (`syncPermissions`/`assignRole` sin límite de subconjunto).
- Mass-assignment de `organization_id` (Client/Supplier/Store/Inventory/Product) + numeración fiscal de Store; IDOR de SupplierContact.
- CashSession `close`/`addTransaction` sin autorización por usuario; Category/Tag sin autorización.
- WooCommerce: SSRF (bloqueo de IPs privadas/reservadas, sin redirects, sin reflejar body) + owner gate + secret oculto.
- Inyección HTML en correos del sistema (`e()`); `voidPayment` TOCTOU (lock + re-chequeo dentro de la transacción).
- Aislamiento por tienda en listas/exports (`User::allowedStoreIds()`).

## 🟡 P2
- `trustProxies` a red privada; throttle en login/register/forgot/reset/google; `random_int`; TTL de token Sanctum (90d); reportes PDF a disco privado; sanitización anti-formula-injection en exports; `@json` en blade admin; gate `report.index` en dashboard.

## Follow-ups (no incluidos, requieren cambios coordinados)
- Recalcular montos de venta server-side + validar `seller_id` (toca el flujo caliente de venta).
- Permiso dedicado `credit.void` (requiere seeder + grant a roles existentes).
- Flujo de step-up server-side para anular/editar facturas (consumido por POS/app dueño).
- PIN por defecto del seller-owner (`1234`) → requiere flujo de cambio forzado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)